### PR TITLE
update s3 file structure

### DIFF
--- a/app/lib/s_three_response_builder.rb
+++ b/app/lib/s_three_response_builder.rb
@@ -18,6 +18,10 @@ class SThreeResponseBuilder
     self.client.get_object({ bucket: self.bucket, key: key })
   end
 
+  def self.list(prefix)
+    self.client.list_objects({ bucket: self.bucket, prefix: prefix })
+  end
+
   private
 
   def self.client


### PR DESCRIPTION
This handles a new S3 file structure, which will allow us to write files directly from a cluster to S3.  Instead of looking for a file at `bucket/year/month/report-name.csv`, it will retrieve the first file nested under the path `bucket/year/month/report-name.csv/`.  This has been tested locally.