### PR TITLE
Es7 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Inital user:
 
 Create an initial user account from the rails console:
 
-    User.create(email: "user@example.com", admin: true, hub: "All", password: "password", password_confimration: "password")
+    User.create(email: "user@example.com", admin: true, hub: "All", password: "password")
 
 ## Testing
 

--- a/app/lib/dpla_api_response_builder.rb
+++ b/app/lib/dpla_api_response_builder.rb
@@ -75,7 +75,12 @@ class DplaApiResponseBuilder
   options = { query: query }
 
     begin
-      json_response('/items', options)['count']
+      count = json_response('/items', options)['count']
+      if (count.is_a? Integer)
+        count # ElasticSearch 6
+      else
+        count['value'] # ElasticSearch 7
+      end
     rescue Exception => e
       Rails.logger.debug(e)
     end


### PR DESCRIPTION
This reads item counts from the DPLA API under ES7 or ES6.  It is backward compatible.  It also fixes an unrelated mistake in the README doc.  This has been tested locally against the ES6 production API and a local ES7 API.