### PR TITLE
strip \" from CSV

### DIFF
--- a/app/lib/metadata_completeness.rb
+++ b/app/lib/metadata_completeness.rb
@@ -102,7 +102,8 @@ class MetadataCompleteness
   # @return CSV
   def csv_data(response)
     # response.body.read is instance of String
-    CSV.new(response.body.read, headers: true)
+    # strip all \" from the body of the CSV to avoid parsing error
+    CSV.new(response.body.read.gsub('\\"', ''), headers: true)
   end
 
   ##


### PR DESCRIPTION
This fixes a bug that was preventing all contributor metadata completeness data from displaying in table view.  The bug was caused by a contributor name in the metadata completeness CSV file containing escaped quotation marks: `\"`.  The presence of these escaped quotation marks cause a parsing error.  This code strips them out.

There is only one contributor name with escaped quotation marks: `"Connecticut State Library. The interview was conducted for a program entitled \"Focus on Connecticut.\""`.  This contributor name is new as of October, which is why the display was working before.  As a result of this code, the metadata completeness data for this one contributor no longer appears in the Hub dashboard because it is no longer an exact match with the contributor name as read through the DPLA and Google Analytics APIs.

This has been tested locally.