### PR TITLE
show mediaAccess completeness

### DIFF
--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -83,7 +83,7 @@ module TooltipsHelper
     These fields are used most heavily in our search and discovery systems,
     and therefore a higher percentage of completeness can lead to more use.
     If a document has mediaAccess, that means that it has either a IIIF manifest
-    or a full-frame media file."
+    or full-frame media file(s)."
   end
 
   def find_tooltip(key)

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -81,7 +81,9 @@ module TooltipsHelper
   def metadata_completeness_tooltip
     "For each field, the percentage of all your metadata records that have a non-null value for that field.
     These fields are used most heavily in our search and discovery systems,
-    and therefore a higher percentage of completeness can lead to more use."
+    and therefore a higher percentage of completeness can lead to more use.
+    If a document has mediaAccess, that means that it has either a IIIF manifest
+    or a full-frame media file."
   end
 
   def find_tooltip(key)

--- a/app/lib/metadata_completeness_presenter.rb
+++ b/app/lib/metadata_completeness_presenter.rb
@@ -3,7 +3,8 @@ class MetadataCompletenessPresenter
   # Fields to be shown in the user interface.
   def self.fields
     [ 'title', 'type', 'subject', 'description', 'preview', 'date', 'creator',
-      'spatial', 'language', 'rights', 'standardizedRights', 'count' ]
+      'spatial', 'language', 'rights', 'standardizedRights', 'mediaAccess',
+      'count' ]
   end
 
   ##


### PR DESCRIPTION
Add media access to the metadata completeness graph.  We may want to change how this is displayed, but this is the first step to simply getting the data out there.  It looks like this: 
<img width="320" alt="Screen Shot 2020-05-29 at 3 36 12 PM" src="https://user-images.githubusercontent.com/3615206/83299776-d0fb1800-a1c4-11ea-83c1-e18ed3ed18f6.png">
The data shows up in hub view and in the contributor breakdown views.