### PR TITLE
Wiki rights

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -134,6 +134,7 @@ class ContributorsController < ApplicationController
     end
 
     mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
+    wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
 
     @contributor_comparison = ContributorComparison.build do |builder|
       builder.hub = params[:hub_id]
@@ -142,6 +143,7 @@ class ContributorsController < ApplicationController
       builder.website_events = website_events
       builder.api_overview = api_overview
       builder.mc_presenter = mc_presenter
+      builder.wp_presenter = wp_presenter
     end
 
     respond_to do |format|

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -84,6 +84,26 @@ class ContributorsController < ApplicationController
     render partial: "shared/metadata_completeness"
   end
 
+  def contributor_wikimedia_overview
+    assign_start_and_end_dates
+
+    metadata_completeness = MetadataCompleteness.build do |builder|
+      builder.hub = params[:hub_id]
+      builder.contributor = params[:contributor_id]
+      builder.end_date = @end_date
+    end
+
+    wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
+    @wp_data = wp_presenter.contributor(params[:hub_id], params[:contributor_id])
+
+    @target = Contributor.new(params[:contributor_id],
+                              params[:hub_id],
+                              @start_date,
+                              @end_date)
+
+    render partial: "shared/wikimedia_overview"
+  end
+
   def contributor_comparison
     assign_start_and_end_dates
     

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -69,6 +69,23 @@ class HubsController < ApplicationController
 
     mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
     @mc_data = mc_presenter.hub(params[:hub_id])
+
     render partial: "shared/metadata_completeness"
+  end
+
+  def wikimedia_overview
+    assign_start_and_end_dates
+
+    metadata_completeness = MetadataCompleteness.build do |builder|
+      builder.hub = params[:hub_id]
+      builder.end_date = @end_date
+    end
+
+    wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
+    @wp_data = wp_presenter.hub(params[:hub_id])
+
+    @target = Hub.new(params[:hub_id], @start_date, @end_date)
+
+    render partial: "shared/wikimedia_overview"
   end
 end

--- a/app/controllers/wikimedia_preparations_controller.rb
+++ b/app/controllers/wikimedia_preparations_controller.rb
@@ -1,0 +1,53 @@
+# Handles HTTP requests for wikimedia readiness
+
+class WikimediaPreparationsController < ApplicationController
+  # Controller concerns
+  include DateSetter
+  # View helpers
+  include DataMenuHelper
+  include DateHelper
+
+  def index
+    assign_start_and_end_dates
+    @hub = Hub.new(params[:hub_id], @start_date, @end_date)
+
+    if params[:contributor_id]
+      @contributor = Contributor.new(params[:contributor_id], params[:hub_id],
+                                     @start_date, @end_date)
+      initiate_contributor_mc_presenter
+    else
+      initiate_hub_mc_presenter
+    end
+
+    @target = params[:contributor_id] ? @contributor : @hub
+
+    @id = params[:id]
+
+    unless current_user.hub == params[:hub_id] || current_user.hub == "All"
+      redirect_to hub_path(current_user.hub)
+    end
+  end
+
+  private
+
+  def initiate_hub_mc_presenter
+    metadata_completeness = MetadataCompleteness.build do |builder|
+      builder.hub = params[:hub_id]
+      builder.end_date = @end_date
+    end
+
+    mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
+    @mc_data = mc_presenter.hub(params[:hub_id])
+  end
+
+  def initiate_contributor_mc_presenter
+    metadata_completeness = MetadataCompleteness.build do |builder|
+      builder.hub = params[:hub_id]
+      builder.contributor = params[:contributor_id]
+      builder.end_date = @end_date
+    end
+
+    mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
+    @mc_data = mc_presenter.contributor(params[:hub_id], params[:contributor_id])
+  end
+end

--- a/app/controllers/wikimedia_preparations_controller.rb
+++ b/app/controllers/wikimedia_preparations_controller.rb
@@ -14,9 +14,9 @@ class WikimediaPreparationsController < ApplicationController
     if params[:contributor_id]
       @contributor = Contributor.new(params[:contributor_id], params[:hub_id],
                                      @start_date, @end_date)
-      initiate_contributor_mc_presenter
+      initiate_contributor_wp_presenter
     else
-      initiate_hub_mc_presenter
+      initiate_hub_wp_presenter
     end
 
     @target = params[:contributor_id] ? @contributor : @hub
@@ -30,24 +30,24 @@ class WikimediaPreparationsController < ApplicationController
 
   private
 
-  def initiate_hub_mc_presenter
+  def initiate_hub_wp_presenter
     metadata_completeness = MetadataCompleteness.build do |builder|
       builder.hub = params[:hub_id]
       builder.end_date = @end_date
     end
 
-    mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
-    @mc_data = mc_presenter.hub(params[:hub_id])
+    wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
+    @wp_data = wp_presenter.hub(params[:hub_id])
   end
 
-  def initiate_contributor_mc_presenter
+  def initiate_contributor_wp_presenter
     metadata_completeness = MetadataCompleteness.build do |builder|
       builder.hub = params[:hub_id]
       builder.contributor = params[:contributor_id]
       builder.end_date = @end_date
     end
 
-    mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
-    @mc_data = mc_presenter.contributor(params[:hub_id], params[:contributor_id])
+    wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
+    @wp_data = wp_presenter.contributor(params[:hub_id], params[:contributor_id])
   end
 end

--- a/app/helpers/data_menu_helper.rb
+++ b/app/helpers/data_menu_helper.rb
@@ -82,6 +82,14 @@ module DataMenuHelper
     link_to("API", path, html_opts(path))
   end
 
+  def render_wikimedia_readiness_link(target)
+    path = target.is_a?(Hub) ?
+      hub_wikimedia_preparations_path(target.name, date_opts) :
+      hub_contributor_wikimedia_preparations_path(target.hub.name, target.name, date_opts)
+
+    link_to("Wikimedia readiness", path, html_opts(path))
+  end
+
   ##
   # Set HTML class to selected if the given path matches the current request
   # path. Parameters (e.g. start_date and end_date) are ignored.

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -86,6 +86,11 @@ module TooltipsHelper
     or full-frame media file(s)."
   end
 
+  def media_access_tooltip
+    "If a document has mediaAccess, that means that it has either a IIIF manifest
+    or full-frame media file(s)."
+  end
+
   def find_tooltip(key)
     case key
     when "view_item"

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -89,6 +89,11 @@ module TooltipsHelper
     or full-frame media file(s)."
   end
 
+  def wikimedia_readiness_tooltip
+    "The number of documents eligible for upload into Wikimedia.  These items
+    have both media access and open licences."
+  end
+
   def find_tooltip(key)
     case key
     when "view_item"

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -90,7 +90,7 @@ module TooltipsHelper
   end
 
   def wikimedia_readiness_tooltip
-    "The number of documents eligible for upload into Wikimedia.  These items
+    "The number of items eligible for upload into Wikimedia.  These items
     have both media access and open rights."
   end
 

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -91,7 +91,7 @@ module TooltipsHelper
 
   def wikimedia_readiness_tooltip
     "The number of documents eligible for upload into Wikimedia.  These items
-    have both media access and open licences."
+    have both media access and open rights."
   end
 
   def find_tooltip(key)

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -81,9 +81,7 @@ module TooltipsHelper
   def metadata_completeness_tooltip
     "For each field, the percentage of all your metadata records that have a non-null value for that field.
     These fields are used most heavily in our search and discovery systems,
-    and therefore a higher percentage of completeness can lead to more use.
-    If a document has mediaAccess, that means that it has either a IIIF manifest
-    or full-frame media file(s)."
+    and therefore a higher percentage of completeness can lead to more use."
   end
 
   def media_access_tooltip

--- a/app/helpers/tooltips_helper.rb
+++ b/app/helpers/tooltips_helper.rb
@@ -85,7 +85,7 @@ module TooltipsHelper
   end
 
   def media_access_tooltip
-    "If a document has mediaAccess, that means that it has either a IIIF manifest
+    "If an item has Media Access, that means that it has either a IIIF manifest
     or full-frame media file(s)."
   end
 

--- a/app/lib/contributor_comparison.rb
+++ b/app/lib/contributor_comparison.rb
@@ -110,14 +110,11 @@ class ContributorComparison
                    "Website Click Throughs",
                    "API Views",
                    "API Users",
-                   "Item Count" ]
+                   "Item Count",
+                   "Wikimedia Ready" ]
 
     MetadataCompletenessPresenter.fields.each do |field|
       attributes.push(field.titleize + " Completeness") unless field == "count"
-    end
-
-    wiki_integration.keys.each do |key|
-      attributes.push(field.titleize)
     end
 
     CSV.generate({ headers: true }) do |csv|
@@ -138,14 +135,11 @@ class ContributorComparison
                 website["Click Throughs"],
                 api["Views"],
                 api["Users"],
-                count ]
+                count,
+                wiki["wikimediaReady"] ]
 
         MetadataCompletenessPresenter.fields.each do |field| 
           data.push(mc[field]) unless field == "count"
-        end
-
-        wiki_integration.keys.each do |key|
-          data.push(wiki[key])
         end
 
         csv << data

--- a/app/lib/wikimedia_preparations_presenter.rb
+++ b/app/lib/wikimedia_preparations_presenter.rb
@@ -11,6 +11,17 @@ class WikimediaPreparationsPresenter
     @metadata_completeness = metadata_completeness
   end
 
+    ##
+  # @param [String]
+  # @return [Array<CSV::Row>]
+  def all_contributors(hub)
+    @metadata_completeness.contributor_csv
+      .find_all { |row| row["provider"] == hub }
+  rescue => e
+    Rails.logger.error(e)
+    Array.new
+  end
+
   ##
   # @param hub [String]
   # @param contributor [String]

--- a/app/lib/wikimedia_preparations_presenter.rb
+++ b/app/lib/wikimedia_preparations_presenter.rb
@@ -2,7 +2,7 @@ class WikimediaPreparationsPresenter
 
   # Fields to be shown in the user interface.
   def self.fields
-    [ 'mediaAccess', 'iiifManifest', 'mediaMaster', 'openLicense', 'wikimediaReady' ]
+    [ 'wikimediaReady', 'mediaAccess', 'openLicense' ]
   end
 
   ##

--- a/app/lib/wikimedia_preparations_presenter.rb
+++ b/app/lib/wikimedia_preparations_presenter.rb
@@ -2,7 +2,7 @@ class WikimediaPreparationsPresenter
 
   # Fields to be shown in the user interface.
   def self.fields
-    [ 'wikimediaReady', 'mediaAccess', 'openLicense' ]
+    [ 'wikimediaReady', 'mediaAccess', 'openRights' ]
   end
 
   ##

--- a/app/lib/wikimedia_preparations_presenter.rb
+++ b/app/lib/wikimedia_preparations_presenter.rb
@@ -1,0 +1,44 @@
+class WikimediaPreparationsPresenter
+
+  # Fields to be shown in the user interface.
+  def self.fields
+    [ 'mediaAccess', 'iiifManifest', 'mediaMaster', 'openLicense', 'wikimediaReady' ]
+  end
+
+  ##
+  # @param [MetadataCompleteness]
+  def initialize(metadata_completeness)
+    @metadata_completeness = metadata_completeness
+  end
+
+  ##
+  # @param hub [String]
+  # @param contributor [String]
+  # @return [Hash]
+  def contributor(hub, contributor)
+    @metadata_completeness.contributor_csv
+      .find { |row| row["provider"] == hub && row["dataProvider"] == contributor }
+      .to_hash
+  rescue => e
+    Rails.logger.error(e)
+    Hash.new
+  end
+
+  ##
+  # @param [String]
+  # @return [Hash]
+  def hub(hub)
+    @metadata_completeness.hub_csv
+      .find { |row| row["provider"] == hub }
+      .to_hash
+  rescue => e
+    Rails.logger.error(e)
+    Hash.new
+  end
+
+  ##
+  # @return Date|nil
+  def file_date
+    @metadata_completeness.file_date
+  end
+end

--- a/app/views/contributors/show.html.erb
+++ b/app/views/contributors/show.html.erb
@@ -34,9 +34,8 @@
               'data-turbolinks-track': 'reload' do %>
           <div>Loading...</div>
         <% end %>
-      </div>
 
-      <div class="metrics">
+        <br/>
 
         <div class="tooltip">
           <h2>API use</h2>
@@ -48,8 +47,9 @@
               'data-turbolinks-track': 'reload' do %>
           <div>Loading...</div>
         <% end %>
+      </div>
 
-        <br/>
+      <div class="metrics">
 
         <div class="tooltip">
           <h2>Item Count</h2>
@@ -58,6 +58,18 @@
 
         <%= render_async hub_contributor_contributor_item_count_path(
               @contributor.hub.name, @contributor.name, date_opts),
+              'data-turbolinks-track': 'reload' do %>
+          <div>Loading...</div>
+        <% end %>
+
+        <br/>
+
+        <div class="tooltip">
+          <h2>Wikimedia Integration</h2>
+        </div>
+
+        <%= render_async  hub_contributor_contributor_wikimedia_overview_path(
+          @contributor.hub.name, @contributor.name, date_opts),
               'data-turbolinks-track': 'reload' do %>
           <div>Loading...</div>
         <% end %>

--- a/app/views/hubs/show.html.erb
+++ b/app/views/hubs/show.html.erb
@@ -33,9 +33,7 @@
           <div>Loading...</div>
         <% end %>
 
-      </div>
-
-      <div class="metrics">
+        <br/>
 
         <div class="tooltip">
           <h2>API use</h2>
@@ -47,7 +45,9 @@
           <div>Loading...</div>
         <% end %>
 
-        <br/>
+      </div>
+
+      <div class="metrics">
 
         <div class="tooltip">
           <h2>Item Count</h2>
@@ -55,6 +55,17 @@
         </div>
 
         <%= render_async hub_item_count_path(@hub.name, date_opts),
+              'data-turbolinks-track': 'reload' do %>
+          <div>Loading...</div>
+        <% end %>
+
+        <br/>
+
+        <div class="tooltip">
+          <h2>Wikimedia Integration</h2>
+        </div>
+
+        <%= render_async  hub_wikimedia_overview_path(@hub.name, date_opts),
               'data-turbolinks-track': 'reload' do %>
           <div>Loading...</div>
         <% end %>

--- a/app/views/shared/_contributor_comparison.html.erb
+++ b/app/views/shared/_contributor_comparison.html.erb
@@ -141,7 +141,9 @@
         </td>
         <%= wr_value = totals["WikimediaIntegration"]["wikimediaReady"] %>
         <td class="wikimedia-ready <%= percentage_class(wr_value) %>">
-          <%= render_percentage(wr_value) %>
+          <% if wr_value %>
+            <%= render_percentage(wr_value) %>
+          <% end %>
         </td>
         <% MetadataCompletenessPresenter.fields.each do |field| %>
           <% unless field == "count" %>

--- a/app/views/shared/_contributor_comparison.html.erb
+++ b/app/views/shared/_contributor_comparison.html.erb
@@ -53,6 +53,15 @@
     </div>
   </fieldset>
   <fieldset>
+    <legend>Wikimedia Integration</legend>
+      <div>
+        <input type="checkbox" id="wikimedia-ready-input" name="column"
+                 value="wikimedia-ready" checked="checked"
+                 onclick="toggle_column(this)">
+        <label for="wikimedia-ready-input">Wikimedia ready</label>
+      </div>
+  </fieldset>
+  <fieldset>
     <legend>Metadata Completeness</legend>
     <% MetadataCompletenessPresenter.fields.each do |field| %>
       <% unless field == 'count' %>
@@ -89,6 +98,7 @@
         <th class="api-user">API Users/Apps</th>
       <% end %>
       <th class="item-count">Item Count</th>
+      <th class="wikimedia-ready">Wikimedia Ready</th>
       <% MetadataCompletenessPresenter.fields.each do |field| %>
         <% unless field == 'count' %>
           <th class="<%= field %>"><%= field.titleize %> Completeness</th>
@@ -128,6 +138,10 @@
         <% end %>
         <td class="item-count">
           <%= totals["ItemCount"] %>
+        </td>
+        <%= wr_value = totals["WikimediaIntegration"]["wikimediaReady"] %>
+        <td class="wikimedia-ready <%= percentage_class(wr_value) %>">
+          <%= render_percentage(wr_value) %>
         </td>
         <% MetadataCompletenessPresenter.fields.each do |field| %>
           <% unless field == "count" %>

--- a/app/views/shared/_contributor_comparison.html.erb
+++ b/app/views/shared/_contributor_comparison.html.erb
@@ -139,7 +139,7 @@
         <td class="item-count">
           <%= totals["ItemCount"] %>
         </td>
-        <%= wr_value = totals["WikimediaIntegration"]["wikimediaReady"] %>
+        <% wr_value = totals["WikimediaIntegration"]["wikimediaReady"] %>
         <td class="wikimedia-ready <%= percentage_class(wr_value) %>">
           <% if wr_value %>
             <%= render_percentage(wr_value) %>

--- a/app/views/shared/_data_menu.html.erb
+++ b/app/views/shared/_data_menu.html.erb
@@ -29,5 +29,8 @@
     <li>
       <%= render_view_api_link(target) %>
     </li>
+    <li>
+      <%= render_wikimedia_readiness_link(target) %>
+    </li>
   </ul>
 </div>

--- a/app/views/shared/_metadata_completeness.html.erb
+++ b/app/views/shared/_metadata_completeness.html.erb
@@ -6,7 +6,14 @@
     <% @mc_data.each do |key, value| %>
       <% if MetadataCompletenessPresenter.fields.include?(key) && key != "count" %>
         <tr>
-          <td><%= key.titleize %></td>
+          <td>
+            <div class="tooltip">
+              <span><%= key.titleize %></span>
+              <% if key == 'mediaAccess' %>
+                <span class="tooltiptext"><%= media_access_tooltip %></span>
+              <% end %>
+            </div>
+          </td>
           <td class="bar <%= percentage_class(value) %>">
             <%= render_percentage(value) %>
           </td>

--- a/app/views/shared/_wikimedia_overview.html.erb
+++ b/app/views/shared/_wikimedia_overview.html.erb
@@ -1,0 +1,30 @@
+<%# Local variables: @wp_data[Hash] @target[Hub|Contributor] %>
+
+<% key = 'wikimediaReady' %>
+
+<% if @wp_data.present? && @wp_data.key?(key) %>
+  <% value = @wp_data[key] %>
+
+  <table>
+    <% if WikimediaPreparationsPresenter.fields.include?(key) %>
+      <tr>
+        <td>
+          <div class="tooltip">
+            <span><%= key.titleize %></span>
+            <span class="tooltiptext"><%= wikimedia_readiness_tooltip %></span>
+          </div>
+        </td>
+        <td class="bar <%= percentage_class(value) %>">
+          <%= render_percentage(value) %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+
+<% else %>
+  <div class="no-data">Data not available</div>
+<% end %>
+
+<br/>
+
+<p>More data about <%= render_wikimedia_readiness_link(@target) %></p>

--- a/app/views/shared/_wikimedia_readiness.html.erb
+++ b/app/views/shared/_wikimedia_readiness.html.erb
@@ -1,0 +1,34 @@
+<%# Local variables: @wr_data[Hash] %>
+
+<h2>Wikimedia Readiness</h2>
+
+<p>To be eligible for uploaded into Wikimedia, items must have both of the following:</p>
+<br/>
+<p>
+  <strong>Media access</strong> - either a IIIF manifest or 
+  full-frame media file(s) (i.e. <em>media master</em>)
+</p>
+<p>
+  <strong>Open license</strong> - a standardized rights statement compatible
+   with wikimedia's licensing policy.
+<p>
+
+<% if @wp_data.present? %>
+
+  <table>
+
+    <% @wp_data.each do |key, value| %>
+      <% if WikimediaPreparationsPresenter.fields.include?(key) %>
+        <tr>
+          <td><%= key.titleize %></td>
+          <td class="bar <%= percentage_class(value) %>">
+            <%= render_percentage(value) %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </table>
+
+<% else %>
+  <div class="no-data">Data not available</div>
+<% end %>

--- a/app/views/shared/_wikimedia_readiness.html.erb
+++ b/app/views/shared/_wikimedia_readiness.html.erb
@@ -16,22 +16,26 @@
   <br/>
 </div>
 
-<% if @wp_data.present? %>
+<div class="metrics">
 
-  <table>
+  <% if @wp_data.present? %>
 
-    <% @wp_data.each do |key, value| %>
-      <% if WikimediaPreparationsPresenter.fields.include?(key) %>
-        <tr>
-          <td><%= key.titleize %></td>
-          <td class="bar <%= percentage_class(value) %>">
-            <%= render_percentage(value) %>
-          </td>
-        </tr>
+    <table>
+
+      <% @wp_data.each do |key, value| %>
+        <% if WikimediaPreparationsPresenter.fields.include?(key) %>
+          <tr>
+            <td><%= key.titleize %></td>
+            <td class="bar <%= percentage_class(value) %>">
+              <%= render_percentage(value) %>
+            </td>
+          </tr>
+        <% end %>
       <% end %>
-    <% end %>
-  </table>
+    </table>
 
-<% else %>
-  <div class="no-data">Data not available</div>
-<% end %>
+  <% else %>
+    <div class="no-data">Data not available</div>
+  <% end %>
+
+</div>

--- a/app/views/shared/_wikimedia_readiness.html.erb
+++ b/app/views/shared/_wikimedia_readiness.html.erb
@@ -10,8 +10,8 @@
     full-frame media file(s)
   </p>
   <p>
-    <strong>Open license</strong> - a standardized rights statement compatible
-     with Wikimedia's licensing policy.
+    <strong>Open rights</strong> - a standardized rights statement or 
+    Creative Commons license compatible with the Wikimedia Commons copyright policy.
   </p>
   <br/>
 </div>

--- a/app/views/shared/_wikimedia_readiness.html.erb
+++ b/app/views/shared/_wikimedia_readiness.html.erb
@@ -2,16 +2,19 @@
 
 <h2>Wikimedia Readiness</h2>
 
-<p>To be eligible for uploaded into Wikimedia, items must have both of the following:</p>
-<br/>
-<p>
-  <strong>Media access</strong> - either a IIIF manifest or 
-  full-frame media file(s) (i.e. <em>media master</em>)
-</p>
-<p>
-  <strong>Open license</strong> - a standardized rights statement compatible
-   with wikimedia's licensing policy.
-<p>
+<div class="description-text">
+  <p>To be ready for upload into Wikimedia, items must have both of the following:</p>
+  <br/>
+  <p>
+    <strong>Media access</strong> - either a IIIF manifest or 
+    full-frame media file(s)
+  </p>
+  <p>
+    <strong>Open license</strong> - a standardized rights statement compatible
+     with Wikimedia's licensing policy.
+  </p>
+  <br/>
+</div>
 
 <% if @wp_data.present? %>
 

--- a/app/views/wikimedia_preparations/index.html.erb
+++ b/app/views/wikimedia_preparations/index.html.erb
@@ -1,0 +1,30 @@
+<%= render partial: "shared/sub_navigation", locals: { hub: @hub } %>
+
+<% content_for :head_script do %>
+  <%= javascript_include_tag 'google-analytics', 
+    'data-turbolinks-track': 'reload', defer: 'defer' %>
+<% end %>
+
+<div class="heading">
+
+  <h1><%= @target.name %></h1>
+
+  <%= render partial: "shared/date_menu" %>
+  
+</div>
+
+<main>
+
+  <%= render partial: "shared/data_menu", locals: { target: @target } %>
+
+  <div class="data-content">
+
+    <div class="data-section">
+
+      <% contributor = @target.is_a?(Contributor) ? @target.name : nil %>
+
+      <p>Hello world</p>
+
+    </div>
+  </div>
+</main>

--- a/app/views/wikimedia_preparations/index.html.erb
+++ b/app/views/wikimedia_preparations/index.html.erb
@@ -23,8 +23,10 @@
 
       <% contributor = @target.is_a?(Contributor) ? @target.name : nil %>
 
-      <p>Hello world</p>
-
+      <%= render partial: "shared/wikimedia_readiness",
+                 locals: { ga_token: GaAuthorizer.token,          
+                           hub: @hub.name,
+                           contributor: contributor } %>
     </div>
   </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,12 +14,14 @@ Rails.application.routes.draw do
     get :api_overview
     get :item_count
     get :metadata_completeness
+    get :wikimedia_overview
 
     resources :contributors, id: /.*/, only: [:index, :show] do
       get :contributor_website_overview
       get :contributor_api_overview
       get :contributor_item_count
       get :contributor_metadata_completeness
+      get :contributor_wikimedia_overview
       resources :events, only: [:show]
       resources :locations, only: [:index]
       resources :timelines, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,11 +23,12 @@ Rails.application.routes.draw do
       resources :events, only: [:show]
       resources :locations, only: [:index]
       resources :timelines, only: [:show]
+      resources :wikimedia_preparations, only: [:index]
     end
     resources :events, only: [:show]
     resources :locations, only: [:index]
     resources :timelines, only: [:show]
-    resources :wikimedia_readiness, only: [:show]
+    resources :wikimedia_preparations, only: [:index]
   end
 
   resources :search_terms, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     resources :events, only: [:show]
     resources :locations, only: [:index]
     resources :timelines, only: [:show]
+    resources :wikimedia_readiness, only: [:show]
   end
 
   resources :search_terms, only: [:show]

--- a/spec/routing/contributors_routing_spec.rb
+++ b/spec/routing/contributors_routing_spec.rb
@@ -63,4 +63,13 @@ describe "contributors routing", type: :routing do
       contributor_id: "bar"
     )
   end
+
+  it "routes /hubs/foo/contributors/bar/contributor_wikimedia_overview for bar" do
+    expect(get: "hubs/foo/contributors/bar/contributor_wikimedia_overview").to route_to(
+      controller: "contributors",
+      action: "contributor_wikimedia_overview",
+      hub_id: "foo",
+      contributor_id: "bar"
+    )
+  end
 end

--- a/spec/routing/hubs_routing_spec.rb
+++ b/spec/routing/hubs_routing_spec.rb
@@ -56,4 +56,12 @@ describe "hubs routing", type: :routing do
       hub_id: "foo"
     )
   end
+
+  it "routes /hubs/foo/wikimedia_overview for foo" do
+    expect(get: "hubs/foo/wikimedia_overview").to route_to(
+      controller: "hubs",
+      action: "wikimedia_overview",
+      hub_id: "foo"
+    )
+  end
 end

--- a/spec/routing/wikimedia_preparations_spec.rb
+++ b/spec/routing/wikimedia_preparations_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe "wikimedia preparations routing", type: :routing do
+
+  it "routes /hubs/foo/wikimedia_preparations to wikimedia_preparations#index" do
+    expect(get: "hubs/foo/wikimedia_preparations").to route_to(
+      controller: "wikimedia_preparations",
+      action: "index",
+      hub_id: "foo"
+    )
+  end
+
+  it "routes /hubs/foo/contributors/bar/wikimedia_preparations to wikimedia_preparations#index" do
+    expect(get: "hubs/foo/contributors/bar/wikimedia_preparations").to route_to(
+      controller: "wikimedia_preparations",
+      action: "index",
+      hub_id: "foo",
+      contributor_id: "bar"
+    )
+  end
+end


### PR DESCRIPTION
This adds data for wikimedia-compliant rights statements and wikimedia readiness.

There is a "Wikimedia Readiness" page for hubs and individual contributors:

<img width="1070" alt="Screen Shot 2020-06-02 at 7 11 56 PM" src="https://user-images.githubusercontent.com/3615206/83578509-f9f11500-a504-11ea-8a48-fffc31d451f3.png">

"Wikimedia Ready" appears on the overview stats page (i.e. the landing page) for hubs and individual contributors.  I imagine that stats about wikimedia use could ultimately be included as well under the "Wikimedia Integration" heading.

<img width="1221" alt="Screen Shot 2020-06-02 at 7 13 24 PM" src="https://user-images.githubusercontent.com/3615206/83578836-b77c0800-a505-11ea-8dc5-1e73a2bac776.png">

A tooltip explaining "Media Access" has been added to the "Metadata Completeness" chart:

<img width="340" alt="Screen Shot 2020-06-02 at 7 18 23 PM" src="https://user-images.githubusercontent.com/3615206/83578973-09249280-a506-11ea-9584-587eb6c331b9.png">

The "Wikimedia ready" datapoint appears in the contributor comparison view.  The blank cells in the screenshot are there b/c I was using a sample of the full dataset.  In production, all cells would have values.

<img width="544" alt="Screen Shot 2020-06-02 at 7 03 50 PM" src="https://user-images.githubusercontent.com/3615206/83578293-5c95e100-a504-11ea-81ef-c99deacaa65c.png">

The "Wikimedia ready" datapoint is also included in the CSV download.
