### PR TITLE
Tweak display

### DIFF
--- a/app/lib/contributor_comparison.rb
+++ b/app/lib/contributor_comparison.rb
@@ -72,21 +72,21 @@ class ContributorComparison
       # TODO: only call API if date range applies
       a_use = api_use_by_contributor[contributor] || {}
       mc = contributor_mc(contributor) || {}
-      wiki_int = wiki_integration(contributor)
+      wp = contributor_wp(contributor) || {}
       data[contributor] = { "Website" => f_use.merge(f_events),
                             "Api" => a_use,
                             "MetadataCompleteness" => mc,
                             "ItemCount" => count,
-                            "WikimediaIntegration" => wiki_int }
+                            "WikimediaIntegration" => wp }
     end
 
     data
   end
 
-  def wiki_integration(contributor)
-    wp = contributor_wp(contributor) || {}
-    { 'wikimediaReady' => wp['wikimediaReady'] }
-  end
+  # def wiki_integration(contributor)
+  #   wp = contributor_wp(contributor) || {}
+  #   { 'wikimediaReady' => wp['wikimediaReady'] }
+  # end
 
   def contributor_mc(contributor)
     all_contributors_mc.find do |row|
@@ -110,8 +110,11 @@ class ContributorComparison
                    "Website Click Throughs",
                    "API Views",
                    "API Users",
-                   "Item Count",
-                   "Wikimedia Ready" ]
+                   "Item Count" ]
+
+    WikimediaPreparationsPresenter.fields.each do |field|
+      attributes.push(field.titleize)
+    end
 
     MetadataCompletenessPresenter.fields.each do |field|
       attributes.push(field.titleize + " Completeness") unless field == "count"
@@ -125,8 +128,8 @@ class ContributorComparison
         website = contributor[1]["Website"]
         api = contributor[1]["Api"]
         mc = contributor[1]["MetadataCompleteness"]
+        wp = contributor[1]["WikimediaIntegration"]
         count = contributor[1]["ItemCount"]
-        wiki = contributor[1]["WikimediaIntegration"]
 
         data =[ contributor[0],
                 website["Sessions"],
@@ -135,8 +138,11 @@ class ContributorComparison
                 website["Click Throughs"],
                 api["Views"],
                 api["Users"],
-                count,
-                wiki["wikimediaReady"] ]
+                count ]
+
+        WikimediaPreparationsPresenter.fields.each do |field|
+          data.push(wp[field])
+        end
 
         MetadataCompletenessPresenter.fields.each do |field| 
           data.push(mc[field]) unless field == "count"

--- a/app/lib/contributor_comparison.rb
+++ b/app/lib/contributor_comparison.rb
@@ -83,11 +83,6 @@ class ContributorComparison
     data
   end
 
-  # def wiki_integration(contributor)
-  #   wp = contributor_wp(contributor) || {}
-  #   { 'wikimediaReady' => wp['wikimediaReady'] }
-  # end
-
   def contributor_mc(contributor)
     all_contributors_mc.find do |row|
       row['dataProvider'] == contributor

--- a/app/lib/metadata_completeness_presenter.rb
+++ b/app/lib/metadata_completeness_presenter.rb
@@ -3,8 +3,7 @@ class MetadataCompletenessPresenter
   # Fields to be shown in the user interface.
   def self.fields
     [ 'title', 'type', 'subject', 'description', 'preview', 'date', 'creator',
-      'spatial', 'language', 'rights', 'standardizedRights', 'mediaAccess',
-      'count' ]
+      'spatial', 'language', 'standardizedRights', 'mediaAccess', 'count' ]
   end
 
   ##

--- a/app/lib/metadata_completeness_presenter.rb
+++ b/app/lib/metadata_completeness_presenter.rb
@@ -3,7 +3,7 @@ class MetadataCompletenessPresenter
   # Fields to be shown in the user interface.
   def self.fields
     [ 'title', 'type', 'subject', 'description', 'preview', 'date', 'creator',
-      'spatial', 'language', 'standardizedRights', 'mediaAccess', 'count' ]
+      'spatial', 'language', 'standardizedRights', 'count' ]
   end
 
   ##

--- a/app/views/shared/_contributor_comparison.html.erb
+++ b/app/views/shared/_contributor_comparison.html.erb
@@ -54,12 +54,14 @@
   </fieldset>
   <fieldset>
     <legend>Wikimedia Integration</legend>
+      <% WikimediaPreparationsPresenter.fields.each do |field| %>
       <div>
-        <input type="checkbox" id="wikimedia-ready-input" name="column"
-                 value="wikimedia-ready" checked="checked"
-                 onclick="toggle_column(this)">
-        <label for="wikimedia-ready-input">Wikimedia ready</label>
+        <input type="checkbox" id="<%= field %>-input" name="column"
+               value="<%= field %>" checked="checked"
+               onclick="toggle_column(this)">
+        <label for="<%= field %>-input"><%= field.titleize %></label>
       </div>
+    <% end %>
   </fieldset>
   <fieldset>
     <legend>Metadata Completeness</legend>
@@ -98,7 +100,9 @@
         <th class="api-user">API Users/Apps</th>
       <% end %>
       <th class="item-count">Item Count</th>
-      <th class="wikimedia-ready">Wikimedia Ready</th>
+      <% WikimediaPreparationsPresenter.fields.each do |field| %>
+        <th class="<%= field %>"><%= field.titleize %></th>
+      <% end %>
       <% MetadataCompletenessPresenter.fields.each do |field| %>
         <% unless field == 'count' %>
           <th class="<%= field %>"><%= field.titleize %> Completeness</th>
@@ -139,12 +143,12 @@
         <td class="item-count">
           <%= totals["ItemCount"] %>
         </td>
-        <% wr_value = totals["WikimediaIntegration"]["wikimediaReady"] %>
-        <td class="wikimedia-ready <%= percentage_class(wr_value) %>">
-          <% if wr_value %>
-            <%= render_percentage(wr_value) %>
-          <% end %>
-        </td>
+        <% WikimediaPreparationsPresenter.fields.each do |field| %>
+          <% value = totals["WikimediaIntegration"][field] %>
+          <td class="<%= field %> <%= percentage_class(value) %>">
+            <%= render_percentage(value) %>
+          </td>
+        <% end %>
         <% MetadataCompletenessPresenter.fields.each do |field| %>
           <% unless field == "count" %>
             <% value = totals["MetadataCompleteness"][field] %>


### PR DESCRIPTION
This makes the following changes to display of wikimedia readiness and metadata completeness:

In the "Metadata completeness" bar graph, "Rights" and "Media access" have been removed.  "Rights" is removed because it is now a required field, so not helpful in this context.  "Media access" is removed because it is already being displayed as part of the "Wikimedia integration" data, and the duplication was confusing.

<img width="304" alt="Screen Shot 2020-07-20 at 12 46 29 PM" src="https://user-images.githubusercontent.com/3615206/87964162-ce5fc500-ca87-11ea-80f0-2ed88ff382ff.png">

In the all contributors view, "Media access" and "Open rights" are now listed in the "Wikimedia integration" section, and have also been added to the CSV download.

<img width="1104" alt="Screen Shot 2020-07-20 at 12 46 03 PM" src="https://user-images.githubusercontent.com/3615206/87964354-1a126e80-ca88-11ea-8cd7-206dc1f322f7.png">
