### PR TITLE
handle zero values from bws api

### DIFF
--- a/app/lib/bws_events_by_contributor.rb
+++ b/app/lib/bws_events_by_contributor.rb
@@ -35,7 +35,7 @@ class BwsEventsByContributor
   end
 
   def parse_data
-    return Hash.new unless response.present?
+    return Hash.new unless (response.rows.present? rescue false)
     # Create Hash of data
     # e.g. "The Library" => { "Click Throughs" => 2, "Total Views" => 5 }
     data = {}

--- a/app/lib/bws_overview_by_contributor.rb
+++ b/app/lib/bws_overview_by_contributor.rb
@@ -35,7 +35,8 @@ class BwsOverviewByContributor
   end
 
   def parse_data
-   # Create Hash of data
+    return Hash.new unless (response.rows.present? rescue false)
+    # Create Hash of data
     # e.g. "The Library" => { "Sessions" => 4, "Users" => 2 }
     columns = response.column_headers.map { |c| c.name }
     data = {}


### PR DESCRIPTION
This fixes a bug that was causing the contributor comparison view not to render.  If there have been no view of BWS materials tracked in Google Analytics, this will no longer try to parse an empty response.