### PR TITLE
handle response from GA showing no API traffic

### DIFF
--- a/app/lib/api_overview_by_contributor.rb
+++ b/app/lib/api_overview_by_contributor.rb
@@ -40,10 +40,12 @@ class ApiOverviewByContributor
     columns = response.column_headers.map { |c| c.name }
     data = {}
 
-    response.rows.map do |r|
-      contributor = r[columns.index("ga:eventAction")]
-      views = r[columns.index("ga:totalEvents")]
-      data[contributor] = { 'Views' => views }
+    if (response.total_results > 0)
+      response.rows.map do |r|
+        contributor = r[columns.index("ga:eventAction")]
+        views = r[columns.index("ga:totalEvents")]
+        data[contributor] = { 'Views' => views }
+      end
     end
 
     data


### PR DESCRIPTION
If a query to the Google Analytics API shows that there has been no traffic on the DPLA API, this handles it gracefully. 