### PR TITLE
Warm WikimediaParticipants P8464 cache at startup

### DIFF
--- a/app/lib/wikimedia_participants.rb
+++ b/app/lib/wikimedia_participants.rb
@@ -40,6 +40,15 @@ class WikimediaParticipants
     wikidata_id.present? && fetch_p8464_ids.include?(wikidata_id)
   end
 
+  ##
+  # Pre-warms both caches (institutions JSON + P8464 IDs). Intended to be
+  # called from an initializer in a background thread so the first real
+  # request hits a warm cache rather than blocking on ~40 Wikidata API calls.
+  #
+  def self.warm_cache!
+    fetch_p8464_ids
+  end
+
   private_class_method def self.fetch_institutions
     Rails.cache.fetch(INSTITUTIONS_KEY, expires_in: CACHE_TTL) do
       uri = URI(INSTITUTIONS_URL)

--- a/config/initializers/wikimedia_participants_cache_warmup.rb
+++ b/config/initializers/wikimedia_participants_cache_warmup.rb
@@ -1,0 +1,18 @@
+# Pre-warms the WikimediaParticipants P8464 cache in a background thread at
+# boot time. Without this, the first request to any hub or contributor page
+# after a deploy blocks for ~30 seconds while ~40 sequential Wikidata API
+# calls are made to populate the cache. Since production uses memory_store
+# (per-process), the cache is cold on every deploy.
+#
+# The thread is daemonised so it doesn't prevent process exit, and all errors
+# are rescued so a transient Wikidata outage cannot prevent the app from
+# starting.
+Rails.application.config.after_initialize do
+  Thread.new do
+    Rails.logger.info("[WikimediaParticipants] Starting cache warm-up in background thread")
+    WikimediaParticipants.warm_cache!
+    Rails.logger.info("[WikimediaParticipants] Cache warm-up complete")
+  rescue StandardError => e
+    Rails.logger.error("[WikimediaParticipants] Cache warm-up failed: #{e.message}")
+  end
+end


### PR DESCRIPTION
## Problem

After each deploy, the in-process `memory_store` cache is cold. The first request to any hub or contributor `sections` endpoint calls `WikimediaParticipants.hub?`, which on a cache miss triggers ~40 sequential Wikidata API batch calls to resolve P8464 claims. This blocks the response thread for ~30 seconds.

## Fix

- Adds `WikimediaParticipants.warm_cache!` public method that populates both the institutions JSON cache and the P8464 ID set.
- Adds `config/initializers/wikimedia_participants_cache_warmup.rb` which calls `warm_cache!` in a background thread via `after_initialize`, so it runs once per Puma process at boot time. All errors are rescued so a transient Wikidata outage cannot prevent startup.

After the ~30s warm-up completes in the background, all subsequent `hub?`/`contributor?` calls return immediately from cache. The first requests during warm-up may still show a slow response if they happen to be the first to hit an empty cache, but this window is minimised to the boot period rather than being indefinite.

## Test plan
- [ ] Deploy and watch ECS logs for `[WikimediaParticipants] Starting cache warm-up` and `Cache warm-up complete` within ~30s of startup
- [ ] Confirm hub pages load quickly after warm-up completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)