### PR TITLE
Raise WikimediaCacheBuilder logs to error level; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ API calls are made via `DplaApiResponseBuilder` (using HTTParty). The API key is
 Monthly metadata completeness reports are stored as CSV files in an S3 bucket. Each file contains field-level completeness percentages for a hub or contributor.
 
 **File layout in S3:**
-```
+```text
 <bucket>/
   YYYY/MM/
     provider.csv      ← hub-level completeness
@@ -160,14 +160,14 @@ All routes require a logged-in user.
 
 **Async partial routes** — the hub and contributor overview pages load all expensive sections with a single async request to a `sections` endpoint, which fetches all data concurrently server-side and returns one combined HTML fragment:
 
-```
+```text
 GET /hubs/:hub_id/sections
 GET /hubs/:hub_id/contributors/:contributor_id/sections
 ```
 
 Individual section routes still exist for sub-pages that load only one section at a time:
 
-```
+```text
 GET /hubs/:hub_id/website_overview
 GET /hubs/:hub_id/api_overview
 GET /hubs/:hub_id/bws_overview
@@ -224,7 +224,7 @@ Subsequent users are created via the admin UI at `/admin/users`. A generated pas
 
 All data views support a `start_date` / `end_date` URL parameter pair in `YYYY-MM` format:
 
-```
+```text
 /hubs/Texas?start_date=2024-06&end_date=2024-06
 ```
 
@@ -281,7 +281,7 @@ Wikimedia Commons analytics are pre-cached in two PostgreSQL tables rather than 
 
 **`wikimedia_cache`** — monthly metrics per hub/contributor:
 
-```
+```text
 wikimedia_cache
   hub             string   — hub name (e.g., "Minnesota Digital Library")
   contributor     string   — contributor name, or "" for hub-level rows
@@ -297,7 +297,7 @@ Each `(hub, contributor, month)` combination is a unique row. `WikimediaAnalytic
 
 **`wikimedia_participants`** — participant status per contributor:
 
-```
+```text
 wikimedia_participants
   hub             string   — hub name
   contributor     string   — contributor name
@@ -313,7 +313,7 @@ A contributor is a Wikimedia pipeline participant if `upload: true` is set on th
 
 The `wikimedia_participants` table is populated at rebuild time by `WikimediaCacheBuilder#sync_participant_flags`. Hub-level `upload: true` cascades to all contributors in that hub. The full table is replaced atomically on each rebuild (delete-all inside a transaction, then re-insert), so removed contributors are cleaned up automatically.
 
-Hub pages do not use `wikimedia_participants` — they rely solely on whether data exists in `wikimedia_cache`.
+Hub pages use `WikimediaParticipant.hub_participant?` to check whether any contributor in the hub has `participant: true`, which determines whether to show "No usage recorded yet" vs "Not a Wikimedia pipeline participant" when no cached data is available.
 
 ### Rebuilding the Cache
 
@@ -330,12 +330,12 @@ Hub pages do not use `wikimedia_participants` — they rely solely on whether da
 
 The rebuild takes approximately 20–30 minutes. Progress is logged at `error` level (the default production `LOG_LEVEL`) so milestones appear in CloudWatch:
 
-```
+```text
 [WikimediaCacheBuilder] Starting rebuild
 [WikimediaCacheBuilder] Synced participant flags for 421 contributors
 [WikimediaCacheBuilder] 2750 work items to process
-[WikimediaCacheBuilder] Phase 1: 423/519 Wikidata IDs resolved to P8464 MediaInfo entities
-[WikimediaCacheBuilder] Phase 2: 421/423 MediaInfo entities resolved to Commons categories
+[WikimediaCacheBuilder] Phase 1: 423/519 Wikidata IDs resolved to P8464 category Q-ids
+[WikimediaCacheBuilder] Phase 2: 421/423 category Q-ids resolved to Commons category names
 [WikimediaCacheBuilder] 2708/2750 items have resolvable Commons categories
 [WikimediaCacheBuilder] Rebuild complete
 ```
@@ -354,18 +354,18 @@ Until the scheduled workflow is deployed, trigger the rebuild manually each mont
 
 Each institution in `institutions_v2.json` has a Wikidata entity ID (e.g., `Q83878485` for the Minnesota Digital Library). The cache builder resolves this to a Commons category name in two batched API phases:
 
-**Phase 1 — Wikidata (wikidata.org):** Fetches P8464 claims in batches of 50 IDs per request. P8464 is the "Commons MediaInfo category" property; entities without a P8464 claim have no Commons category and are skipped.
+**Phase 1 — Wikidata (wikidata.org):** Fetches P8464 claims in batches of 50 IDs per request. P8464 links each institution's Wikidata item to the Wikidata item for its Commons category (e.g., `Q112194444` → `Q113547185`). Entities without a P8464 claim have no Commons category and are skipped.
 
-**Phase 2 — Commons (commons.wikimedia.org):** Fetches sitelinks for the resolved MediaInfo entity IDs in batches of 50. Extracts the `commonswiki` sitelink title, strips the `"Category:"` prefix, and replaces spaces with underscores.
+**Phase 2 — Wikidata (wikidata.org):** Fetches sitelinks for the resolved category Q-ids in batches of 50. Extracts the `commonswiki` sitelink title, strips the `"Category:"` prefix, and replaces spaces with underscores to produce the CIM API category name.
 
-```
-Wikidata entity ID  (e.g., Q83878485)
+```text
+Wikidata entity ID  (e.g., Q112194444)
   ↓ Phase 1: wbgetentities?ids=...&props=claims  (batches of 50)
   claims.P8464[0].mainsnak.datavalue.value.id
-  ↓ MediaInfo entity ID  (e.g., M97584242)
+  ↓ Commons category Q-id  (e.g., Q113547185)
   ↓ Phase 2: wbgetentities?ids=...&props=sitelinks  (batches of 50)
   sitelinks.commonswiki.title  →  strip "Category:", replace spaces with "_"
-  ↓ Commons category name  (e.g., "Media_contributed_by_the_Minnesota_Digital_Library")
+  ↓ Commons category name  (e.g., "Media_contributed_by_Northwest_Digital_Heritage")
 ```
 
 Each phase reuses a single TLS connection for all batches to minimize overhead.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ A Rails application that aggregates analytics data from multiple sources to prov
   - [Data Builders and Presenters](#data-builders-and-presenters)
 - [Wikimedia Cache System](#wikimedia-cache-system)
   - [How It Works](#how-it-works)
+  - [Participant Status](#participant-status)
   - [Rebuilding the Cache](#rebuilding-the-cache)
+  - [Scheduled Automatic Rebuild](#scheduled-automatic-rebuild)
   - [Wikidata Resolution Chain](#wikidata-resolution-chain)
 - [Infrastructure and Deployment](#infrastructure-and-deployment)
   - [AWS Architecture](#aws-architecture)
   - [Deploying a Change](#deploying-a-change)
+  - [Database Migrations in Production](#database-migrations-in-production)
   - [One-Off Tasks in Production](#one-off-tasks-in-production)
 - [Local Development Setup](#local-development-setup)
   - [Prerequisites](#prerequisites)
@@ -155,7 +158,14 @@ All routes require a logged-in user.
 | `/hubs/:hub_id/wikimedia_preparations` | Wikimedia Commons readiness metrics |
 | `/contributor_comparison` | Full contributor comparison export (HTML + CSV) |
 
-**Async partial routes** — the hub and contributor overview pages load expensive sections via `render_async`. Each has a dedicated route that returns an HTML fragment:
+**Async partial routes** — the hub and contributor overview pages load all expensive sections with a single async request to a `sections` endpoint, which fetches all data concurrently server-side and returns one combined HTML fragment:
+
+```
+GET /hubs/:hub_id/sections
+GET /hubs/:hub_id/contributors/:contributor_id/sections
+```
+
+Individual section routes still exist for sub-pages that load only one section at a time:
 
 ```
 GET /hubs/:hub_id/website_overview
@@ -174,7 +184,7 @@ GET /hubs/:hub_id/wikimedia_overview
 | `GET/POST /admin/users/new` | Create a user |
 | `GET/PATCH /admin/users/:id/edit` | Edit user permissions |
 | `DELETE /admin/users/:id` | Delete a user |
-| `POST /admin/wikimedia_cache/rebuild` | Trigger a Wikimedia cache rebuild |
+| `POST /admin/wikimedia_cache/rebuild` | Trigger an on-demand Wikimedia cache rebuild |
 
 **Other**
 
@@ -218,22 +228,20 @@ All data views support a `start_date` / `end_date` URL parameter pair in `YYYY-M
 /hubs/Texas?start_date=2024-06&end_date=2024-06
 ```
 
-When no params are provided, the date range defaults to the current month. The `DateSetter` concern (included by all controllers) parses and validates these params, clamping them to the configured `min_date` and the current date.
+When no params are provided, the date range defaults to all-time data. The `DateSetter` concern (included by all controllers) parses and validates these params, clamping them to the configured `min_date` and the current date.
 
-Links between pages preserve the selected date range. When the current month is selected (the default), date params are omitted from URLs to keep them clean.
+Links between pages preserve the selected date range.
 
 ---
 
 ### Async Rendering
 
-Hub and contributor overview pages use the [`render_async`](https://github.com/rendercoffee/render_async) gem to load each metric section independently. This means:
+Hub and contributor overview pages use the [`render_async`](https://github.com/rendercoffee/render_async) gem to load metric sections independently from the initial page render. A single async request is made to the `sections` endpoint, which executes all data fetches concurrently in server-side threads and returns a combined HTML fragment. This means:
 
 - The page structure renders immediately
-- Each metric section fires its own background HTTP request
-- Slow sections (e.g., GA4 calls) don't block faster ones (e.g., item counts)
-- Individual sections can fail without taking down the whole page
-
-Each async section has a dedicated controller action and route. The partial is rendered into a `<div>` placeholder and swapped in via JavaScript when the request completes.
+- All metric sections are fetched in one background request via concurrent threads
+- Slow sections (e.g., GA4 calls) don't block faster ones (e.g., item counts from the DPLA API)
+- Individual data fetches can fail without taking down the whole page
 
 ---
 
@@ -258,7 +266,7 @@ Data fetching is organized into a library of plain Ruby classes in `app/lib/`. T
 | `DplaApiResponseBuilder` | DPLA API | Item counts and contributor lists |
 | `SThreeResponseBuilder` | AWS S3 | Metadata completeness CSVs |
 | `MetadataCompleteness` | S3 CSVs | Parses field-level completeness data |
-| `WikimediaCacheBuilder` | Wikidata + CIM API | Populates the PostgreSQL Wikimedia cache |
+| `WikimediaCacheBuilder` | Wikidata + CIM API | Populates the PostgreSQL Wikimedia cache tables |
 | `WikimediaAnalyticsPresenter` | PostgreSQL cache | Formats Wikimedia metrics for display |
 | `WikimediaPreparationsPresenter` | Wikidata | Wikimedia readiness metrics |
 | `ContributorComparison` | All sources | Combines all metrics for the comparison table/CSV |
@@ -269,7 +277,9 @@ Data fetching is organized into a library of plain Ruby classes in `app/lib/`. T
 
 ### How It Works
 
-Wikimedia Commons analytics are pre-cached in a PostgreSQL table (`wikimedia_cache`) rather than fetched live. The table schema is:
+Wikimedia Commons analytics are pre-cached in two PostgreSQL tables rather than fetched live on every page load.
+
+**`wikimedia_cache`** — monthly metrics per hub/contributor:
 
 ```
 wikimedia_cache
@@ -283,43 +293,82 @@ wikimedia_cache
   created_at / updated_at
 ```
 
-Each `(hub, contributor, month)` combination is a unique row. The `WikimediaAnalyticsPresenter` queries this table with the selected date range, summing `page_views` across months and taking the maximum of the cumulative snapshot fields within the range.
+Each `(hub, contributor, month)` combination is a unique row. `WikimediaAnalyticsPresenter` queries this table with the selected date range, summing `page_views` across months and taking the maximum of the cumulative snapshot fields within the range.
+
+**`wikimedia_participants`** — participant status per contributor:
+
+```
+wikimedia_participants
+  hub             string   — hub name
+  contributor     string   — contributor name
+  participant     boolean  — true if upload: true in institutions_v2.json
+  created_at / updated_at
+```
+
+Each `(hub, contributor)` pair is unique. This table is read at page load to choose the appropriate "no data" message: participants with no cached data yet see "No usage recorded yet across Wikimedia"; non-participants see "Not a Wikimedia pipeline participant."
+
+### Participant Status
+
+A contributor is a Wikimedia pipeline participant if `upload: true` is set on that contributor or its parent hub in `institutions_v2.json`. Having a Wikidata ID alone does not imply participation — all cultural institutions may have Wikidata IDs regardless of whether they contribute files to Wikimedia Commons.
+
+The `wikimedia_participants` table is populated at rebuild time by `WikimediaCacheBuilder#sync_participant_flags`. Hub-level `upload: true` cascades to all contributors in that hub. The full table is replaced atomically on each rebuild (delete-all inside a transaction, then re-insert), so removed contributors are cleaned up automatically.
+
+Hub pages do not use `wikimedia_participants` — they rely solely on whether data exists in `wikimedia_cache`.
 
 ### Rebuilding the Cache
 
-**Via the admin UI:** Go to `/admin/users` and click **Rebuild Wikimedia Cache**. The rebuild runs in a background thread and takes several minutes. A flash notice confirms the job was started.
-
-**Via rake task:**
-```bash
-bundle exec rake wikimedia:rebuild_cache
-```
+**Via the admin UI:** Go to `/admin/users` and click **Rebuild Wikimedia Cache**. Use this for on-demand rebuilds (e.g., after a new hub is onboarded, or to recover from a failed scheduled run). The rebuild runs in a background thread; a flash notice confirms it was started. The button disables on click to prevent double-submission.
 
 **What the rebuild does:**
 
-1. Fetches `institutions_v2.json` from the ingestion3 repository — the authoritative list of hubs and contributors with their Wikidata IDs.
-2. Resolves each unique Wikidata ID to a Wikimedia Commons category name (see below). This step is sequential to avoid rate-limiting by Wikidata.
-3. Spawns a pool of 20 worker threads. Each thread picks work items off a queue and fetches data from the CIM API for its assigned category.
-4. For each category, fetches all historical snapshot data and all historical pageview data in single wide-range API calls.
-5. Upserts the results into `wikimedia_cache`. Snapshot fields and pageview fields are upserted separately so that a failed call for one doesn't overwrite cached values for the other with `nil`.
+1. Fetches `institutions_v2.json` from the ingestion3 repository.
+2. Writes participant flags to `wikimedia_participants` (atomic delete + re-insert in a transaction).
+3. Resolves each unique Wikidata ID to a Wikimedia Commons category name via two batched MediaWiki API phases (see [Wikidata Resolution Chain](#wikidata-resolution-chain)).
+4. Spawns a pool of 20 worker threads. Each thread picks work items off a queue and fetches CIM API data for its assigned Commons category.
+5. For each category, fetches all historical snapshot and pageview data in single wide-range API calls.
+6. Upserts the results into `wikimedia_cache`. Snapshot fields and pageview fields are upserted separately so that a failed call for one does not overwrite cached values for the other with `nil`.
 
-**Monthly automatic rebuild** is planned for the 8th of each month via an EventBridge scheduled task. Until that scheduler is deployed, use the admin button or rake task each month after the ingestion cycle completes.
+The rebuild takes approximately 20–30 minutes. Progress is logged at `error` level (the default production `LOG_LEVEL`) so milestones appear in CloudWatch:
+
+```
+[WikimediaCacheBuilder] Starting rebuild
+[WikimediaCacheBuilder] Synced participant flags for 421 contributors
+[WikimediaCacheBuilder] 2750 work items to process
+[WikimediaCacheBuilder] Phase 1: 423/519 Wikidata IDs resolved to P8464 MediaInfo entities
+[WikimediaCacheBuilder] Phase 2: 421/423 MediaInfo entities resolved to Commons categories
+[WikimediaCacheBuilder] 2708/2750 items have resolvable Commons categories
+[WikimediaCacheBuilder] Rebuild complete
+```
+
+### Scheduled Automatic Rebuild
+
+The cache should be rebuilt monthly after the ingestion cycle closes. The planned approach is a **scheduled GitHub Actions workflow** that triggers the rebuild on the 8th of each month.
+
+**To implement:**
+1. Add `.github/workflows/wikimedia-cache-rebuild.yml` with `on: schedule: - cron: '0 12 8 * *'` (noon UTC on the 8th).
+2. The workflow should invoke `rake wikimedia:rebuild_cache` via a one-off ECS task (see [One-Off Tasks in Production](#one-off-tasks-in-production)), or POST to the rebuild endpoint with admin credentials stored as GitHub Actions secrets.
+
+Until the scheduled workflow is deployed, trigger the rebuild manually each month via the admin UI button after the ingestion cycle completes.
 
 ### Wikidata Resolution Chain
 
-Each institution in `institutions_v2.json` has a Wikidata entity ID (e.g., `Q83878485` for the Minnesota Digital Library). The cache builder resolves this to a Commons category name using two Wikidata API calls per unique ID:
+Each institution in `institutions_v2.json` has a Wikidata entity ID (e.g., `Q83878485` for the Minnesota Digital Library). The cache builder resolves this to a Commons category name in two batched API phases:
+
+**Phase 1 — Wikidata (wikidata.org):** Fetches P8464 claims in batches of 50 IDs per request. P8464 is the "Commons MediaInfo category" property; entities without a P8464 claim have no Commons category and are skipped.
+
+**Phase 2 — Commons (commons.wikimedia.org):** Fetches sitelinks for the resolved MediaInfo entity IDs in batches of 50. Extracts the `commonswiki` sitelink title, strips the `"Category:"` prefix, and replaces spaces with underscores.
 
 ```
-Wikidata entity ID (e.g., Q83878485)
-  → fetch entity JSON from wikidata.org
-  → extract claims.P8464[0] (MediaInfo entity on Commons)
-  → get the Commons entity ID (e.g., Q97584242)
-  → fetch that entity's JSON
-  → extract sitelinks.commonswiki.title
-  → strip "Category:" prefix, replace spaces with underscores
-  → Commons category name (e.g., "Media_contributed_by_the_Minnesota_Digital_Library")
+Wikidata entity ID  (e.g., Q83878485)
+  ↓ Phase 1: wbgetentities?ids=...&props=claims  (batches of 50)
+  claims.P8464[0].mainsnak.datavalue.value.id
+  ↓ MediaInfo entity ID  (e.g., M97584242)
+  ↓ Phase 2: wbgetentities?ids=...&props=sitelinks  (batches of 50)
+  sitelinks.commonswiki.title  →  strip "Category:", replace spaces with "_"
+  ↓ Commons category name  (e.g., "Media_contributed_by_the_Minnesota_Digital_Library")
 ```
 
-This category name is then used in CIM API calls. Both Wikidata lookups reuse a single TLS connection per institution to minimize overhead.
+Each phase reuses a single TLS connection for all batches to minimize overhead.
 
 ---
 
@@ -333,7 +382,6 @@ This category name is then used in CIM API calls. Both Wikidata lookups reuse a 
 | ECS Service | `analytics-dashboard` |
 | ECR Repository | `283408157088.dkr.ecr.us-east-1.amazonaws.com/analytics-dashboard` |
 | CodePipeline | `analytics-dashboard-pipeline` |
-| CodeBuild Project | See pipeline |
 | Deployment strategy | Blue/green via CodeDeploy (auto-rollback on failure) |
 | Load balancer | Shared ALB (`baggins`) — routed by host header |
 | Secrets Manager | `arn:aws:secretsmanager:us-east-1:283408157088:secret:terraform-20240821214923751700000001-7CZ7Cq` |
@@ -352,6 +400,7 @@ This category name is then used in CIM API calls. Both Wikidata lookups reuse a 
 | `DB_HOST` / `DB_USERNAME` / `DB_PASSWORD` | PostgreSQL credentials |
 | `SENTRY_DSN` | Sentry error tracking |
 | `SMTP_PASSWORD` | AWS SES credentials for outbound email |
+| `LOG_LEVEL` | Rails log level (defaults to `error` if unset — `warn` or `info` for more verbosity) |
 
 **CodePipeline note:** The pipeline has a stale webhook (a known AWS CodeStar Connections migration issue) and does not auto-trigger on push to `main`. It must be started manually after merging:
 
@@ -367,21 +416,53 @@ Use the `deploy-analytics-dashboard` Claude skill, which enforces the correct or
 2. **Merge the PR** — squash merge and delete the branch. Do not merge before the image is built.
 3. **Start the pipeline** — start `analytics-dashboard-pipeline` manually (stale webhook).
 4. **Monitor** — CodeBuild compiles assets (~2 min), then CodeDeploy performs the blue/green ECS swap (~5–8 min).
-5. **Verify** — health check: `curl -I https://analytics-dashboard.dp.la`
+5. **Run migrations** — if the deployment includes new migrations, run them as a one-off ECS task (see below).
+6. **Verify** — health check: `curl -I https://analytics-dashboard.dp.la`
 
-If the deployment includes new database migrations, they run automatically as part of the Docker entrypoint (`bundle exec rails db:migrate`) before the Rails server starts.
+### Database Migrations in Production
 
-### One-Off Tasks in Production
-
-To run a rake task or Rails runner against the production database, use ECS `run-task` with the current ECR image:
+**Migrations do not run automatically as part of the ECS deployment.** After deploying code that adds new migrations, run them as a separate one-off ECS task:
 
 ```bash
 aws ecs run-task \
   --cluster analytics-dashboard \
-  --task-definition analytics-dashboard \
+  --task-definition arn:aws:ecs:us-east-1:283408157088:task-definition/analytics-dashboard:<VERSION> \
   --launch-type FARGATE \
-  --network-configuration "awsvpcConfiguration={subnets=[<subnet>],securityGroups=[<sg>],assignPublicIp=ENABLED}" \
-  --overrides '{"containerOverrides":[{"name":"analytics-dashboard","environment":[{"name":"DISABLE_SPRING","value":"1"}],"command":["bundle","exec","rake","wikimedia:rebuild_cache"]}]}'
+  --network-configuration '{"awsvpcConfiguration":{"subnets":["subnet-0e6dbb3a02a55a416","subnet-00f8056d6e59465ca"],"securityGroups":["sg-09e35b96da021355c"],"assignPublicIp":"ENABLED"}}' \
+  --overrides '{"containerOverrides":[{"name":"analytics-dashboard-container","command":["bundle","exec","rails","db:migrate"],"environment":[{"name":"DISABLE_SPRING","value":"1"}]}]}'
+```
+
+`DISABLE_SPRING=1` is required — Spring's preloader fails in the production environment and causes the task to exit with code 1 without it.
+
+Get the current task definition version:
+```bash
+aws ecs describe-services --cluster analytics-dashboard --services analytics-dashboard \
+  --query 'services[0].taskDefinition' --output text
+```
+
+After the task stops, check the exit code and view migration output in CloudWatch:
+```bash
+aws ecs describe-tasks --cluster analytics-dashboard --tasks <TASK_ARN> \
+  --query 'tasks[0].{status:lastStatus,exit:containers[0].exitCode}'
+
+aws logs get-log-events \
+  --log-group-name /ecs/analytics-dashboard \
+  --log-stream-name "ecs/analytics-dashboard-container/<TASK_ID>"
+```
+
+**Important:** After running migrations that add new tables or indexes, the running ECS tasks have a stale schema cache and may not recognize the new schema until restarted. If application code immediately uses the new schema (e.g., `upsert_all` with `unique_by`), restart the task after migrating by stopping it — ECS will automatically start a replacement with a fresh schema cache.
+
+### One-Off Tasks in Production
+
+To run a rake task or Rails runner against the production database, use ECS `run-task` with `DISABLE_SPRING=1`:
+
+```bash
+aws ecs run-task \
+  --cluster analytics-dashboard \
+  --task-definition arn:aws:ecs:us-east-1:283408157088:task-definition/analytics-dashboard:<VERSION> \
+  --launch-type FARGATE \
+  --network-configuration '{"awsvpcConfiguration":{"subnets":["subnet-0e6dbb3a02a55a416","subnet-00f8056d6e59465ca"],"securityGroups":["sg-09e35b96da021355c"],"assignPublicIp":"ENABLED"}}' \
+  --overrides '{"containerOverrides":[{"name":"analytics-dashboard-container","environment":[{"name":"DISABLE_SPRING","value":"1"}],"command":["bundle","exec","rake","wikimedia:rebuild_cache"]}]}'
 ```
 
 ---
@@ -391,7 +472,7 @@ aws ecs run-task \
 ### Prerequisites
 
 - Ruby 3.1.2 (use `rbenv` or `asdf`)
-- Rails 7.1 (`gem 'rails', '~> 7.1.0'` — note: `config.load_defaults` is intentionally kept at `7.0`; see [Known Issues](#rails-71-load_defaults-pinned-at-70))
+- Rails 7.2
 - Bundler 2.x
 - SQLite 3 (development database)
 - Node.js (for asset compilation if needed)
@@ -498,15 +579,11 @@ The Black Women's Suffrage (BWS) digital exhibit at [blackwomenssuffrage.dp.la](
 
 ### Missing Data — Primary Source Sets
 
-Primary Source Set (PSS) page view data is not tracked in the dashboard. The PSS pages on dp.la fire GA4 analytics events, but no PSS-specific query or metric section exists in the dashboard. This is a gap in the GA4 migration work.
+Primary Source Set (PSS) page view data is not tracked in the dashboard. The PSS pages on dp.la fire GA4 analytics events, but no PSS-specific query or metric section exists in the dashboard.
 
-### Wikimedia Cache — No Automatic Rebuild
+### Wikimedia Cache — No Scheduled Rebuild
 
-The Wikimedia cache must be rebuilt manually each month (via the admin UI button or `rake wikimedia:rebuild_cache`). An EventBridge scheduled task to run the rebuild automatically on the 8th of each month is planned but not yet deployed. Until the scheduler exists, stale data will accumulate after the ingestion cycle closes for the month.
-
-### Wikimedia Cache — Stale Rows
-
-The cache rebuild is additive (upsert-only). If an institution is removed from `institutions_v2.json` or its Wikidata ID becomes unresolvable, its old rows remain in the table and continue to appear in the dashboard. A cleanup pass to delete rows not touched by the most recent rebuild is not yet implemented.
+The Wikimedia cache must currently be rebuilt manually each month via the admin UI button. A scheduled GitHub Actions workflow to trigger the rebuild automatically on the 8th of each month has not yet been implemented. See [Scheduled Automatic Rebuild](#scheduled-automatic-rebuild) for the planned approach.
 
 ### Metadata Completeness — Monthly Lag
 
@@ -515,10 +592,6 @@ Metadata completeness CSVs are generated as part of the monthly ingestion cycle 
 ### Contributor Comparison — Potential Timeouts
 
 The contributor comparison page (`/contributor_comparison`) makes parallel GA4 API calls for every contributor in a hub. For hubs with many contributors, this can be slow and may time out under heavy load. The page includes a CSV export option for offline analysis.
-
-### Rails 7.1 — `load_defaults` Pinned at 7.0
-
-The app runs Rails 7.1 but `config/application.rb` calls `config.load_defaults 7.0`. Upgrading to `load_defaults 7.1` enables several behavior changes (notably `ActiveRecord::Base.automatically_invert_plural_associations`) that have not been reviewed or tested. The pin is intentional until a compatibility audit is done.
 
 ### Hard-Coded Configuration
 

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -91,9 +91,14 @@ class HubsController < ApplicationController
     rescue => e
       Rails.logger.error(e); {}
     end
+    participant_t = Thread.new do
+      WikimediaParticipant.hub_participant?(hub_id)
+    rescue => e
+      Rails.logger.error(e); false
+    end
 
     [item_count_t, contributor_t, website_views_t, wiki_views_t,
-     website_overview_t, website_events_t, mc_thread].each(&:join)
+     website_overview_t, website_events_t, mc_thread, participant_t].each(&:join)
 
     mc_data = mc_thread.value || {}
 
@@ -106,6 +111,7 @@ class HubsController < ApplicationController
     @wp_data              = mc_data[:wp]
     @wa_data              = mc_data[:wa]
     @mc_data              = mc_data[:mc]
+    @wikimedia_participant = participant_t.value
     @target               = Hub.new(hub_id, sec_start, sec_end)
 
     render partial: "shared/hub_sections"
@@ -258,8 +264,9 @@ class HubsController < ApplicationController
     )
     @wa_data = wa_presenter.hub(params[:hub_id])
 
-    @item_count = item_count_thread.value
-    @target     = Hub.new(params[:hub_id], @start_date, @end_date)
+    @item_count            = item_count_thread.value
+    @wikimedia_participant = WikimediaParticipant.hub_participant?(params[:hub_id])
+    @target                = Hub.new(params[:hub_id], @start_date, @end_date)
 
     render partial: "shared/wikimedia_overview"
   end

--- a/app/lib/wikimedia_cache_builder.rb
+++ b/app/lib/wikimedia_cache_builder.rb
@@ -19,7 +19,7 @@ class WikimediaCacheBuilder
   end
 
   def rebuild
-    Rails.logger.warn "[WikimediaCacheBuilder] Starting rebuild"
+    Rails.logger.error "[WikimediaCacheBuilder] Starting rebuild"
     institutions = fetch_json(INSTITUTIONS_URL)
 
     # Sync contributor participant flags to DB first (fast, DB-only, no external calls).
@@ -27,7 +27,7 @@ class WikimediaCacheBuilder
 
     work_items   = build_work_items(institutions)
 
-    Rails.logger.warn "[WikimediaCacheBuilder] #{work_items.size} work items to process"
+    Rails.logger.error "[WikimediaCacheBuilder] #{work_items.size} work items to process"
 
     # Resolve each unique Wikidata ID to a Commons category in batches of 50
     # via the anonymous MediaWiki API (~55 requests for Phase 1, ~8 for Phase 2).
@@ -35,7 +35,7 @@ class WikimediaCacheBuilder
     wikidata_to_cat = batch_resolve_commons_categories(unique_ids)
 
     processable = work_items.select { |i| wikidata_to_cat.key?(i[:wikidata_id]) }
-    Rails.logger.warn "[WikimediaCacheBuilder] #{processable.size}/#{work_items.size} items have resolvable Commons categories"
+    Rails.logger.error "[WikimediaCacheBuilder] #{processable.size}/#{work_items.size} items have resolvable Commons categories"
 
     queue = Queue.new
     processable.each { |item| queue << item }
@@ -52,7 +52,7 @@ class WikimediaCacheBuilder
     end
 
     threads.each(&:join)
-    Rails.logger.warn "[WikimediaCacheBuilder] Rebuild complete"
+    Rails.logger.error "[WikimediaCacheBuilder] Rebuild complete"
   end
 
   private
@@ -89,7 +89,7 @@ class WikimediaCacheBuilder
       end
     end
 
-    Rails.logger.warn "[WikimediaCacheBuilder] Synced participant flags for #{rows.size} contributors"
+    Rails.logger.error "[WikimediaCacheBuilder] Synced participant flags for #{rows.size} contributors"
   end
 
   def build_work_items(institutions)
@@ -118,7 +118,7 @@ class WikimediaCacheBuilder
         .first&.dig("mainsnak", "datavalue", "value", "id")
     end
 
-    Rails.logger.warn "[WikimediaCacheBuilder] Phase 1: #{wikidata_to_m_id.size}/#{wikidata_ids.size} Wikidata IDs resolved to P8464 MediaInfo entities"
+    Rails.logger.error "[WikimediaCacheBuilder] Phase 1: #{wikidata_to_m_id.size}/#{wikidata_ids.size} Wikidata IDs resolved to P8464 MediaInfo entities"
 
     # Phase 2: Commons — resolve each MediaInfo entity ID to a category name
     unique_m_ids     = wikidata_to_m_id.values.uniq
@@ -127,7 +127,7 @@ class WikimediaCacheBuilder
       title&.sub(/\ACategory:/i, "")&.gsub(" ", "_")
     end
 
-    Rails.logger.warn "[WikimediaCacheBuilder] Phase 2: #{m_id_to_category.size}/#{unique_m_ids.size} MediaInfo entities resolved to Commons categories"
+    Rails.logger.error "[WikimediaCacheBuilder] Phase 2: #{m_id_to_category.size}/#{unique_m_ids.size} MediaInfo entities resolved to Commons categories"
 
     # Combine: map wikidata_id -> category_name
     wikidata_to_m_id.each_with_object({}) do |(wikidata_id, m_id), result|
@@ -152,7 +152,7 @@ class WikimediaCacheBuilder
         response = http.get("#{uri.path}?#{URI.encode_www_form(params)}", headers)
         if response.is_a?(Net::HTTPTooManyRequests)
           wait = response["Retry-After"]&.to_i || 10
-          Rails.logger.warn "[WikimediaCacheBuilder] 429 from #{uri.host}, retrying in #{wait}s"
+          Rails.logger.error "[WikimediaCacheBuilder] 429 from #{uri.host}, retrying in #{wait}s"
           sleep(wait)
           response = http.get("#{uri.path}?#{URI.encode_www_form(params)}", headers)
         end
@@ -160,7 +160,7 @@ class WikimediaCacheBuilder
         data = JSON.parse(response.body)
 
         if data["error"]
-          Rails.logger.warn "[WikimediaCacheBuilder] #{uri.host} API error: #{data['error']['code']}: #{data['error']['info']}"
+          Rails.logger.error "[WikimediaCacheBuilder] #{uri.host} API error: #{data['error']['code']}: #{data['error']['info']}"
           failed += 1
           next
         end
@@ -172,11 +172,11 @@ class WikimediaCacheBuilder
         end
       rescue StandardError => e
         failed += 1
-        Rails.logger.warn "[WikimediaCacheBuilder] #{uri.host} batch failed: #{e.message}"
+        Rails.logger.error "[WikimediaCacheBuilder] #{uri.host} batch failed: #{e.message}"
       end
     end
 
-    Rails.logger.warn "[WikimediaCacheBuilder] #{uri.host}: #{result.size} resolved, #{failed} batches failed" if failed > 0
+    Rails.logger.error "[WikimediaCacheBuilder] #{uri.host}: #{result.size} resolved, #{failed} batches failed" if failed > 0
     result
   end
 
@@ -236,7 +236,7 @@ class WikimediaCacheBuilder
       hash[month] = item if month
     end
   rescue StandardError => e
-    Rails.logger.warn "[WikimediaCacheBuilder] fetch_snapshot failed for #{category}: #{e.message}"
+    Rails.logger.error "[WikimediaCacheBuilder] fetch_snapshot failed for #{category}: #{e.message}"
     {}
   end
 
@@ -254,7 +254,7 @@ class WikimediaCacheBuilder
       hash[month] = views.to_i if month && views
     end
   rescue StandardError => e
-    Rails.logger.warn "[WikimediaCacheBuilder] fetch_pageviews failed for #{category}: #{e.message}"
+    Rails.logger.error "[WikimediaCacheBuilder] fetch_pageviews failed for #{category}: #{e.message}"
     {}
   end
 

--- a/app/lib/wikimedia_cache_builder.rb
+++ b/app/lib/wikimedia_cache_builder.rb
@@ -4,7 +4,6 @@ require "json"
 class WikimediaCacheBuilder
   INSTITUTIONS_URL  = "https://raw.githubusercontent.com/dpla/ingestion3/main/src/main/resources/wiki/institutions_v2.json"
   WIKIDATA_API_URL  = "https://www.wikidata.org/w/api.php"
-  COMMONS_API_URL   = "https://commons.wikimedia.org/w/api.php"
   CIM_BASE_URL      = "https://wikimedia.org/api/rest_v1/metrics/commons-analytics"
   # Fetch all months in one call by using a wide date window.
   # Snapshot: /{category}/{start}/{end}  — date format YYYYMMDD
@@ -107,31 +106,34 @@ class WikimediaCacheBuilder
   end
 
   # Resolves an array of Wikidata IDs to Commons category names in two batched
-  # phases via the anonymous MediaWiki API (50 IDs per request):
-  #   Phase 1 — wikidata.org: fetch P8464 claims to get MediaInfo entity IDs
-  #   Phase 2 — commons.wikimedia.org: fetch sitelinks to get category titles
+  # phases via the Wikidata API (50 IDs per request):
+  #   Phase 1 — fetch P8464 claims: each institution's Wikidata item carries a
+  #              P8464 value that is the Q-id of the Wikidata item for its
+  #              Commons category (e.g. Q112194444 → Q113547185).
+  #   Phase 2 — fetch sitelinks for those category Q-ids: the commonswiki
+  #              sitelink title gives the Commons category name
+  #              (e.g. "Category:Media contributed by Northwest Digital Heritage").
   # Returns { wikidata_id => category_name } for all successfully resolved IDs.
   def batch_resolve_commons_categories(wikidata_ids)
-    # Phase 1: Wikidata — resolve each ID to a MediaInfo entity ID via P8464 claim
-    wikidata_to_m_id = batch_fetch_entities(WIKIDATA_API_URL, wikidata_ids, "claims") do |entity|
+    # Phase 1: resolve each institution/hub Wikidata ID to its Commons category Q-id via P8464
+    wikidata_to_cat_qid = batch_fetch_entities(WIKIDATA_API_URL, wikidata_ids, "claims") do |entity|
       (entity.dig("claims", "P8464") || [])
         .first&.dig("mainsnak", "datavalue", "value", "id")
     end
 
-    Rails.logger.error "[WikimediaCacheBuilder] Phase 1: #{wikidata_to_m_id.size}/#{wikidata_ids.size} Wikidata IDs resolved to P8464 MediaInfo entities"
+    Rails.logger.error "[WikimediaCacheBuilder] Phase 1: #{wikidata_to_cat_qid.size}/#{wikidata_ids.size} Wikidata IDs resolved to P8464 category Q-ids"
 
-    # Phase 2: Commons — resolve each MediaInfo entity ID to a category name
-    unique_m_ids     = wikidata_to_m_id.values.uniq
-    m_id_to_category = batch_fetch_entities(COMMONS_API_URL, unique_m_ids, "sitelinks") do |entity|
+    # Phase 2: resolve each category Q-id to its Commons category name via commonswiki sitelink
+    unique_cat_qids  = wikidata_to_cat_qid.values.uniq
+    cat_qid_to_name  = batch_fetch_entities(WIKIDATA_API_URL, unique_cat_qids, "sitelinks") do |entity|
       title = entity.dig("sitelinks", "commonswiki", "title")
       title&.sub(/\ACategory:/i, "")&.gsub(" ", "_")
     end
 
-    Rails.logger.error "[WikimediaCacheBuilder] Phase 2: #{m_id_to_category.size}/#{unique_m_ids.size} MediaInfo entities resolved to Commons categories"
+    Rails.logger.error "[WikimediaCacheBuilder] Phase 2: #{cat_qid_to_name.size}/#{unique_cat_qids.size} category Q-ids resolved to Commons category names"
 
-    # Combine: map wikidata_id -> category_name
-    wikidata_to_m_id.each_with_object({}) do |(wikidata_id, m_id), result|
-      cat = m_id_to_category[m_id]
+    wikidata_to_cat_qid.each_with_object({}) do |(wikidata_id, cat_qid), result|
+      cat = cat_qid_to_name[cat_qid]
       result[wikidata_id] = cat if cat
     end
   end

--- a/app/models/wikimedia_participant.rb
+++ b/app/models/wikimedia_participant.rb
@@ -13,4 +13,8 @@ class WikimediaParticipant < ApplicationRecord
   def self.participant?(hub, contributor)
     where(hub: hub, contributor: contributor).pick(:participant) || false
   end
+
+  def self.hub_participant?(hub)
+    where(hub: hub, participant: true).exists?
+  end
 end


### PR DESCRIPTION
## Summary

- **Log level**: All `Rails.logger.warn` calls in `WikimediaCacheBuilder` raised to `Rails.logger.error` so rebuild progress and errors are visible in CloudWatch under production's default `LOG_LEVEL=error` setting (`warn` is filtered out at the default level)
- **Hub participant flag**: Add `WikimediaParticipant.hub_participant?(hub)` and call it from `HubsController#sections` (concurrently in a thread) and `HubsController#wikimedia_overview`, so hub pages correctly show "No usage recorded yet" instead of "Not a Wikimedia pipeline participant" for hubs like NWDH whose uploads are attributed to contributor institutions rather than the hub entity directly
- **Phase 2 API fix**: `batch_resolve_commons_categories` resolves Wikidata IDs in two steps — Phase 1 fetches the P8464 claim (a category Q-id) from each institution's Wikidata item; Phase 2 fetches the commonswiki sitelink from that category Q-id to get the Commons category name. Both phases query Wikidata items, so both should use `WIKIDATA_API_URL`. The original code used `COMMONS_API_URL` for Phase 2, which happens to work (Commons can serve Wikidata items) but makes no sense when Wikidata is the authoritative source and is already used for Phase 1. Also removes the now-unused `COMMONS_API_URL` constant and renames misleading `m_id` variables to `cat_qid`.
- **README**: Comprehensive update reflecting last month's Wikimedia cache work — two-table architecture (`wikimedia_cache` + `wikimedia_participants`), participant status sync, async `sections` endpoint, scheduled rebuild plan (GitHub Actions on 8th of month, UI button for on-demand only), and new "Database Migrations in Production" section documenting the manual migration procedure, `DISABLE_SPRING=1` requirement, and schema cache restart

## Test plan

- [ ] Trigger a Wikimedia cache rebuild from the admin UI and verify progress messages appear in CloudWatch logs
- [ ] Confirm error conditions (429 retries, batch failures) are visible in CloudWatch
- [ ] Verify NWDH hub page shows "No usage recorded yet" rather than "Not a Wikimedia pipeline participant" after rebuild completes
- [ ] Review README for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded hub/contributor and cache docs: single-request concurrent metric loading for heavy sections, default date-range = “all-time”, cache schema split into monthly metrics and participant status, clarified on-demand rebuild and planned monthly cron (8th); added deployment/migrations guidance, LOG_LEVEL env var, and local Rails 7.2 upgrade.
* **New Features**
  * Hub pages detect and surface participant status to control “no data” messaging.
* **Improvements**
  * Rebuild and related lifecycle logs now use more prominent error-level reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->