### PR TITLE
Reduce CIM concurrency to 1 and add linear-backoff retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 
 /config/settings.yml
 /config/google-analytics-key.json
+google-analytics-key.json
 /config/database.yml
 
 .vagrant

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Hub pages use `WikimediaParticipant.hub_participant?` to check whether any contr
 5. For each category, fetches all historical snapshot and pageview data in single wide-range API calls.
 6. Upserts the results into `wikimedia_cache`. Snapshot fields and pageview fields are upserted separately so that a failed call for one does not overwrite cached values for the other with `nil`.
 
-The rebuild takes approximately 10 minutes. Progress is logged at `error` level (the default production `LOG_LEVEL`) so milestones appear in CloudWatch:
+The rebuild takes approximately 20–30 minutes. CIM API requests are intentionally serialised (one at a time) to avoid rate limiting. Progress is logged at `error` level (the default production `LOG_LEVEL`) so milestones appear in CloudWatch:
 
 ```text
 [WikimediaCacheBuilder] Starting rebuild

--- a/app/lib/wikimedia_cache_builder.rb
+++ b/app/lib/wikimedia_cache_builder.rb
@@ -13,11 +13,12 @@ class WikimediaCacheBuilder
   CIM_PAGEVIEWS_URL = "#{CIM_BASE_URL}/pageviews-per-category-monthly/%s/deep/all-wikis/00000101/99991231"
   THREAD_POOL_SIZE  = 20
   BATCH_SIZE        = 50  # MediaWiki anonymous API limit
-  # Limits concurrent in-flight CIM HTTP requests across all worker threads.
-  # The CIM API throttles at the storage layer with no published hard limit;
-  # 4 concurrent slots keeps us well within observed tolerance while still
-  # completing a full rebuild in a reasonable time.
-  CIM_CONCURRENCY   = 4
+  # Serialises all CIM HTTP requests to a single in-flight connection.
+  # The CIM API has no published rate limit and throttles at the storage layer;
+  # since the rebuild only runs monthly, throughput is not a concern and
+  # sequential access is the safest way to avoid 429s entirely.
+  CIM_CONCURRENCY   = 1
+  CIM_MAX_RETRIES   = 3
 
   def self.rebuild
     new.rebuild
@@ -299,15 +300,21 @@ class WikimediaCacheBuilder
     JSON.parse(response.body)
   end
 
-  # Performs an HTTP GET and retries once on 429, honoring Retry-After (default 10s).
+  # Performs an HTTP GET, retrying up to CIM_MAX_RETRIES times on 429.
+  # Uses linear backoff (Retry-After × attempt number) so the storage layer
+  # has progressively more time to recover between attempts.
   def http_get_with_retry(http, request_uri, headers)
     response = http.get(request_uri, headers)
-    return response unless response.is_a?(Net::HTTPTooManyRequests)
-
-    wait = parse_retry_after(response["Retry-After"])
-    Rails.logger.error "[WikimediaCacheBuilder] 429 from #{http.address}, retrying in #{wait}s"
-    sleep(wait)
-    http.get(request_uri, headers)
+    CIM_MAX_RETRIES.times do |attempt|
+      break unless response.is_a?(Net::HTTPTooManyRequests)
+      base_wait = parse_retry_after(response["Retry-After"])
+      wait      = base_wait * (attempt + 1)
+      Rails.logger.error "[WikimediaCacheBuilder] 429 from #{http.address}, " \
+                         "retry #{attempt + 1}/#{CIM_MAX_RETRIES} in #{wait}s"
+      sleep(wait)
+      response = http.get(request_uri, headers)
+    end
+    response
   end
 
   # Parses a Retry-After header value (integer seconds or HTTP-date).

--- a/app/lib/wikimedia_cache_builder.rb
+++ b/app/lib/wikimedia_cache_builder.rb
@@ -300,9 +300,11 @@ class WikimediaCacheBuilder
     JSON.parse(response.body)
   end
 
-  # Performs an HTTP GET, retrying up to CIM_MAX_RETRIES times on 429.
-  # Uses linear backoff (Retry-After × attempt number) so the storage layer
-  # has progressively more time to recover between attempts.
+  # Performs an HTTP GET with up to CIM_MAX_RETRIES additional attempts on 429
+  # (1 initial request + CIM_MAX_RETRIES retries = 4 total attempts).
+  # Uses linear backoff (Retry-After × attempt number). With CIM_CONCURRENCY=1
+  # the sleep holds the semaphore slot, pausing all CIM work during backoff —
+  # intentional, as it gives the storage layer time to recover.
   def http_get_with_retry(http, request_uri, headers)
     response = http.get(request_uri, headers)
     CIM_MAX_RETRIES.times do |attempt|

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -16,7 +16,7 @@
           style: "margin-left: 1em;" %>
     <span style="margin-left: 0.5em; font-size: 0.85em; color: #777;">
       Monthly automatic rebuild planned for the 8th of each month.
-      The rebuild runs in the background and takes approximately 10 minutes.
+      The rebuild runs in the background and takes approximately 20&ndash;30 minutes.
     </span>
   </div>
 


### PR DESCRIPTION
## Summary

- `CIM_CONCURRENCY` 4 → 1: fully serialises CIM requests (one at a time), eliminating the burst that triggers storage-layer 429s. The rebuild is monthly so throughput is not a concern.
- `CIM_MAX_RETRIES` 1 → 3: retries up to 3 times on 429 with linear backoff (Retry-After × attempt: 1×, 2×, 3×) as a safety net for any transient throttling.
- Updates rebuild time estimate to 20–30 minutes in README and admin UI.

**Root cause:** With `CIM_CONCURRENCY=4`, production logs showed 720 retries fired and 362 categories still failing after the single retry — the 4 concurrent slots were still generating more burst than the storage layer could absorb. `CIM_CONCURRENCY=1` removes all concurrency pressure.

## Test plan

- [ ] Trigger a Wikimedia cache rebuild from `/admin/users` and confirm it completes with no 429 errors in CloudWatch logs
- [ ] Confirm NWDH and other previously missing hubs/contributors now show data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limiting handling in the cache rebuild process with automatic retry logic (up to 3 attempts per request with linear backoff).

* **Documentation**
  * Updated Wikimedia cache rebuild duration estimate from approximately 10 minutes to 20–30 minutes across documentation and user-facing interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->