### PR TITLE
Cache Hub#contributors to reduce redundant DPLA API calls

### DIFF
--- a/app/lib/dpla_api_response_builder.rb
+++ b/app/lib/dpla_api_response_builder.rb
@@ -31,7 +31,7 @@ class DplaApiResponseBuilder
 
   ##
   # @param [String]
-  # @return [Array<String>]
+  # @return [Array<String>, nil] nil on API error; [] for a hub with no contributors
   #
   def contributors(hub)
     options = { query: { :api_key => api_key,

--- a/app/lib/dpla_api_response_builder.rb
+++ b/app/lib/dpla_api_response_builder.rb
@@ -46,7 +46,7 @@ class DplaApiResponseBuilder
     rescue StandardError => e
       Sentry.capture_exception(e)
       Rails.logger.debug(e)
-      Array.new
+      nil
     end
   end
 

--- a/app/lib/dpla_api_response_builder.rb
+++ b/app/lib/dpla_api_response_builder.rb
@@ -41,7 +41,9 @@ class DplaApiResponseBuilder
                          :'provider.name' => hub } }
 
     begin
-      (json_response('/items', options).dig('facets', 'dataProvider', 'terms') || [])
+      result = json_response('/items', options)
+      return nil if result == {}
+      (result.dig('facets', 'dataProvider', 'terms') || [])
         .map{ |f| f['term'] }
     rescue StandardError => e
       Sentry.capture_exception(e)

--- a/app/lib/hub.rb
+++ b/app/lib/hub.rb
@@ -48,7 +48,12 @@ class Hub
   # Get names of all contributors that belonging to this hub
   # @return [Array<String>]
   def contributors
-    @contributors ||= self.class.dpla_api.contributors(name).sort
+    @contributors ||= Rails.cache.fetch("hub:#{name}:contributors", expires_in: 1.hour) do
+      self.class.dpla_api.contributors(name).sort
+    end
+  rescue => e
+    Rails.logger.warn("Hub#contributors failed for #{name}: #{e.message}")
+    []
   end
 
   protected

--- a/app/lib/hub.rb
+++ b/app/lib/hub.rb
@@ -53,7 +53,7 @@ class Hub
     end || []
   rescue => e
     Rails.logger.warn("Hub#contributors failed for #{name} (#{e.class}): #{e.message}\n#{e.backtrace&.first(3)&.join("\n")}")
-    []
+    @contributors = []
   end
 
   protected

--- a/app/lib/hub.rb
+++ b/app/lib/hub.rb
@@ -52,7 +52,7 @@ class Hub
       self.class.dpla_api.contributors(name).sort
     end
   rescue => e
-    Rails.logger.warn("Hub#contributors failed for #{name}: #{e.message}")
+    Rails.logger.warn("Hub#contributors failed for #{name} (#{e.class}): #{e.message}\n#{e.backtrace&.first(3)&.join("\n")}")
     []
   end
 

--- a/app/lib/hub.rb
+++ b/app/lib/hub.rb
@@ -48,9 +48,9 @@ class Hub
   # Get names of all contributors that belonging to this hub
   # @return [Array<String>]
   def contributors
-    @contributors ||= Rails.cache.fetch("hub:#{name}:contributors", expires_in: 1.hour) do
-      self.class.dpla_api.contributors(name).sort
-    end
+    @contributors ||= Rails.cache.fetch("hub:#{name}:contributors", expires_in: 1.hour, skip_nil: true) do
+      self.class.dpla_api.contributors(name).sort.presence
+    end || []
   rescue => e
     Rails.logger.warn("Hub#contributors failed for #{name} (#{e.class}): #{e.message}\n#{e.backtrace&.first(3)&.join("\n")}")
     []

--- a/app/lib/hub.rb
+++ b/app/lib/hub.rb
@@ -49,7 +49,7 @@ class Hub
   # @return [Array<String>]
   def contributors
     @contributors ||= Rails.cache.fetch("hub:#{name}:contributors", expires_in: 1.hour, skip_nil: true) do
-      self.class.dpla_api.contributors(name).sort.presence
+      self.class.dpla_api.contributors(name)&.sort
     end || []
   rescue => e
     Rails.logger.warn("Hub#contributors failed for #{name} (#{e.class}): #{e.message}\n#{e.backtrace&.first(3)&.join("\n")}")


### PR DESCRIPTION
## Summary

- **Cache `Hub#contributors`** with a 1-hour TTL in `Rails.cache`, matching the existing `Hub.all_with_counts` pattern
- **Add model-layer rescue** so API failures return `[]` instead of propagating to the view (fixes DPLA-FRONTEND-1FY)

## Problem

`Hub#contributors` is called on every page load via the nav partial (`_navigation.html.erb`) with no caching — every page navigation made a fresh API call to `/items` with a `dataProvider` facet. The async `sections` endpoint made a second identical call. A single user browsing a few pages could trigger 10+ redundant API calls in seconds, enough to cause 5xx responses from api.dp.la.

This caused three Sentry issues on 2026-04-09 (timed to a new user's first login):
- **DPLA-FRONTEND-1FY** — `HttpServerError` in nav partial (crashed the page)
- **DPLA-FRONTEND-1HR** — `HttpServerError` in `item_count` (sections endpoint)
- **DPLA-FRONTEND-1HQ** — `HttpServerError` in `contributors` (sections endpoint)

## Test plan

- [ ] Verify hub pages load correctly with the Contributors nav link visible
- [ ] Verify nav degrades gracefully (hides Contributors link) when API is unavailable
- [ ] Confirm subsequent page loads hit cache instead of API (check Rails logs for absence of `/items` calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contributor retrieval now fails gracefully: errors and malformed API responses are logged and an empty contributor list is returned to avoid user-facing errors or inconsistent displays.

* **Performance**
  * Contributor lists are cached short-term to reduce repeated external requests and improve load times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->