### PR TITLE
Bump addressable to 2.9.0 (ReDoS fix)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,8 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.1)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     awesome_print (1.9.2)
     aws-eventstream (1.4.0)
     aws-partitions (1.1226.0)
@@ -295,7 +295,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (5.0.1)
+    public_suffix (6.0.2)
     puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)


### PR DESCRIPTION
## Summary

- Bumps `addressable` from 2.8.1 → 2.9.0 (transitive dependency via `google-apis-core` and `signet`)
- Resolves Dependabot alert #146 (high severity): Regular Expression Denial of Service in Addressable URI template parsing

## Test plan

- [ ] Verify CodeQL and CI pass
- [ ] Deploy and confirm hub pages / API calls function normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)