### PR TITLE
Show item/contributor counts immediately without waiting for GA4

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -25,6 +25,9 @@ class ContributorsController < ApplicationController
                                    @start_date,
                                    @end_date)
 
+    # Pre-load S3-cached count so the totals card renders on initial page load.
+    @item_count = Hub.item_count(params[:hub_id], params[:id])
+
     unless current_user.hub == params[:hub_id] || current_user.hub == "All"
       redirect_to hub_path(current_user.hub)
     end

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -24,6 +24,10 @@ class HubsController < ApplicationController
     end
     @wikimedia_start_date = Date.parse("#{first_month}-01") if first_month
 
+    # Pre-load S3-cached counts so the totals card renders on initial page load.
+    @item_count        = Hub.item_count(params[:id])
+    @contributor_count = Hub.contributor_count(params[:id])
+
     unless current_user.hub == params[:id] || current_user.hub == "All"
       redirect_to hub_path(current_user.hub)
     end

--- a/app/lib/hub.rb
+++ b/app/lib/hub.rb
@@ -43,6 +43,14 @@ class Hub
 
   ##
   # @param hub [String]
+  # @return [Integer]
+  #
+  def self.contributor_count(hub)
+    (HubStats.fetch.dig("hubs", hub, "contributors") || {}).size
+  end
+
+  ##
+  # @param hub [String]
   # @return [Array<Hash>] [{ "term" => name, "count" => count }, ...] sorted by count desc
   #
   def self.contributors_item_count(hub)

--- a/app/views/contributors/show.html.erb
+++ b/app/views/contributors/show.html.erb
@@ -23,7 +23,9 @@
           @contributor.hub.name, @contributor.name, date_opts) do %>
       <div class="data-section">
         <div class="metrics-left-col">
-          <div class="metrics"><div>Loading...</div></div>
+          <div class="metrics">
+            <%= render partial: "shared/totals" %>
+          </div>
           <div class="metrics"><div>Loading...</div></div>
         </div>
         <div class="metrics"><div>Loading...</div></div>

--- a/app/views/hubs/show.html.erb
+++ b/app/views/hubs/show.html.erb
@@ -21,7 +21,9 @@
     <%= render_async_section hub_sections_path(@hub.name, date_opts) do %>
       <div class="data-section">
         <div class="metrics-left-col">
-          <div class="metrics"><div>Loading...</div></div>
+          <div class="metrics">
+            <%= render partial: "shared/totals" %>
+          </div>
           <div class="metrics"><div>Loading...</div></div>
         </div>
         <div class="metrics"><div>Loading...</div></div>


### PR DESCRIPTION
## Summary

- The Totals card (Items, Contributors) now renders on initial page load from the S3 cache (~100ms TTFB) rather than being blank until the async GA4 sections request finishes (3–8s)
- The three GA4-backed sections (DPLA Website, Wikimedia Integration, Metadata Completeness) still show `Loading...` as before — this only affects the fast stats
- Also adds `Hub.contributor_count` to avoid the unnecessary `.keys.sort` on the full array just to get a count

## How it works

`HubsController#show` and `ContributorsController#show` now pre-load `@item_count` / `@contributor_count` from the 24h Rails cache (backed by the S3 snapshot). The `render_async_section` placeholder renders `shared/totals` with the real values instead of `Loading...`. When the async sections request completes, the Turbo Frame replaces the block (now also including GA4 view counts in the Totals card).

## Test plan

- [ ] Visit a hub page — Totals card (Items + Contributors) should appear immediately on page load, before the other three sections fill in
- [ ] Visit a contributor page — Items count should appear immediately
- [ ] After GA4 sections load, Totals card should refresh to include Views on dp.la / Views on Wikimedia rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Hub and contributor detail pages now immediately display item counts, contributor totals, and key metrics upon initial page load, completely eliminating the "Loading..." placeholder experience. Users now see complete and accurate statistics instantly, resulting in a faster and significantly more responsive interface without waiting for background data fetching operations to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->