### PR TITLE
Show full page skeleton immediately; numbers fill in after async fetch

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -27,6 +27,7 @@ class ContributorsController < ApplicationController
 
     # Pre-load S3-cached count so the totals card renders on initial page load.
     @item_count = Hub.item_count(params[:hub_id], params[:id])
+    @target     = @contributor
 
     unless current_user.hub == params[:hub_id] || current_user.hub == "All"
       redirect_to hub_path(current_user.hub)

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -27,6 +27,7 @@ class HubsController < ApplicationController
     # Pre-load S3-cached counts so the totals card renders on initial page load.
     @item_count        = Hub.item_count(params[:id])
     @contributor_count = Hub.contributor_count(params[:id])
+    @target            = @hub
 
     unless current_user.hub == params[:id] || current_user.hub == "All"
       redirect_to hub_path(current_user.hub)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,11 @@ module ApplicationHelper
   # the async request fails instead of silently replacing the container with
   # an empty string.
   #
+  # Returns a formatted number or an em dash when value is nil (still loading).
+  def dash_or(value, delimiter: ',')
+    value.nil? ? "—" : number_with_delimiter(value, delimiter: delimiter)
+  end
+
   def render_async_section(path, options = {}, &block)
     default_error = '<div class="error-message">Data unavailable. Please try refreshing.</div>'
     render_async(path, { error_message: default_error }.merge(options), &block)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,15 +1,15 @@
 module ApplicationHelper
 
-  ##
-  # Wrapper around render_async that adds a default error message shown when
-  # the async request fails instead of silently replacing the container with
-  # an empty string.
-  #
   # Returns a formatted number or an em dash when value is nil (still loading).
   def dash_or(value, delimiter: ',')
     value.nil? ? "—" : number_with_delimiter(value, delimiter: delimiter)
   end
 
+  ##
+  # Wrapper around render_async that adds a default error message shown when
+  # the async request fails instead of silently replacing the container with
+  # an empty string.
+  #
   def render_async_section(path, options = {}, &block)
     default_error = '<div class="error-message">Data unavailable. Please try refreshing.</div>'
     render_async(path, { error_message: default_error }.merge(options), &block)

--- a/app/views/contributors/show.html.erb
+++ b/app/views/contributors/show.html.erb
@@ -21,16 +21,7 @@
 
     <%= render_async_section hub_contributor_sections_path(
           @contributor.hub.name, @contributor.name, date_opts) do %>
-      <div class="data-section">
-        <div class="metrics-left-col">
-          <div class="metrics">
-            <%= render partial: "shared/totals" %>
-          </div>
-          <div class="metrics"><div>Loading...</div></div>
-        </div>
-        <div class="metrics"><div>Loading...</div></div>
-        <div class="metrics"><div>Loading...</div></div>
-      </div>
+      <%= render partial: "shared/contributor_sections" %>
     <% end %>
 
   </div>

--- a/app/views/hubs/show.html.erb
+++ b/app/views/hubs/show.html.erb
@@ -19,16 +19,7 @@
   <div class="data-content">
 
     <%= render_async_section hub_sections_path(@hub.name, date_opts) do %>
-      <div class="data-section">
-        <div class="metrics-left-col">
-          <div class="metrics">
-            <%= render partial: "shared/totals" %>
-          </div>
-          <div class="metrics"><div>Loading...</div></div>
-        </div>
-        <div class="metrics"><div>Loading...</div></div>
-        <div class="metrics"><div>Loading...</div></div>
-      </div>
+      <%= render partial: "shared/hub_sections" %>
     <% end %>
 
   </div>

--- a/app/views/shared/_frontend_use_metrics.html.erb
+++ b/app/views/shared/_frontend_use_metrics.html.erb
@@ -1,7 +1,39 @@
 <%# Local variables: @website_overview [WebsiteOverview],
                      @website_event_totals [WebsiteEventTotals] %>
 
-<% if @website_overview.error? || @website_event_totals.error? %>
+<% if @website_overview.nil? %>
+  <table>
+    <tr>
+      <td><div class="tooltip">Item views<span class="tooltiptext"><%= view_item_tooltip %></span></div></td>
+      <td>—</td>
+    </tr>
+    <tr class="subitem">
+      <td><div class="tooltip">Digital library catalog<span class="tooltiptext"><%= view_metadata_record_tooltip %></span></div></td>
+      <td>—</td>
+    </tr>
+    <tr class="subitem">
+      <td><div class="tooltip">Exhibition<span class="tooltiptext"><%= view_exhibition_tooltip %></span></div></td>
+      <td>—</td>
+    </tr>
+    <tr class="subitem">
+      <td><div class="tooltip">Primary source set<span class="tooltiptext"><%= view_primary_source_set_tooltip %></span></div></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td><div class="tooltip">Click throughs<span class="tooltiptext"><%= click_through_tooltip %></span></div></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td><div class="tooltip">Users<span class="tooltiptext"><%= users_tooltip %></span></div></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td><div class="tooltip">Sessions<span class="tooltiptext"><%= sessions_tooltip %></span></div></td>
+      <td>—</td>
+    </tr>
+  </table>
+
+<% elsif @website_overview&.error? || @website_event_totals&.error? %>
   <p class="error-note">Data unavailable — GA4 query failed. Try refreshing the page.</p>
 <% else %>
 

--- a/app/views/shared/_frontend_use_metrics.html.erb
+++ b/app/views/shared/_frontend_use_metrics.html.erb
@@ -1,7 +1,7 @@
 <%# Local variables: @website_overview [WebsiteOverview],
                      @website_event_totals [WebsiteEventTotals] %>
 
-<% if @website_overview.nil? %>
+<% if @website_overview.nil? || @website_event_totals.nil? %>
   <table>
     <tr>
       <td><div class="tooltip">Item views<span class="tooltiptext"><%= view_item_tooltip %></span></div></td>

--- a/app/views/shared/_metadata_completeness.html.erb
+++ b/app/views/shared/_metadata_completeness.html.erb
@@ -4,25 +4,27 @@
   <p class="not-time-bound-note">Metadata completeness reflects the current state of your records and is not affected by the selected date range.</p>
 <% end %>
 
-<% if @mc_data.present? %>
+<%# nil = still loading (show skeleton); present = has data; blank non-nil = no data %>
+<% if @mc_data.nil? || @mc_data.present? %>
 
   <table>
-    <% @mc_data.each do |key, value| %>
-      <% if MetadataCompletenessPresenter.fields.include?(key) && key != "count" %>
-        <tr>
-          <td>
-            <div class="tooltip">
-              <span><%= key.titleize %></span>
-              <% if key == 'mediaAccess' %>
-                <span class="tooltiptext"><%= media_access_tooltip %></span>
-              <% end %>
-            </div>
-          </td>
-          <td class="bar <%= percentage_class(value) %>">
-            <%= render_percentage(value) %>
-          </td>
-        </tr>
-      <% end %>
+    <% MetadataCompletenessPresenter.fields.reject { |f| f == "count" }.each do |key| %>
+      <%# When data is loaded, only show keys returned by the API %>
+      <% next if @mc_data && !@mc_data.key?(key) %>
+      <% value = @mc_data&.[](key) %>
+      <tr>
+        <td>
+          <div class="tooltip">
+            <span><%= key.titleize %></span>
+            <% if key == 'mediaAccess' %>
+              <span class="tooltiptext"><%= media_access_tooltip %></span>
+            <% end %>
+          </div>
+        </td>
+        <td class="bar <%= percentage_class(value) unless value.nil? %>">
+          <%= value.nil? ? "—" : render_percentage(value) %>
+        </td>
+      </tr>
     <% end %>
   </table>
 

--- a/app/views/shared/_totals.html.erb
+++ b/app/views/shared/_totals.html.erb
@@ -13,8 +13,10 @@
     <p class="not-time-bound-note">These totals reflect current data and are not affected by the selected date range.</p>
   <% end %>
 
+  <%# nil means still loading; treat as "data may arrive" so the row stays visible %>
   <% any_data = @item_count.to_i > 0 || @contributor_count.to_i > 0 ||
-                @website_views.to_i > 0 || @wikimedia_views.to_i > 0 %>
+                @website_views.nil? || @website_views.to_i > 0 ||
+                @wikimedia_views.nil? || @wikimedia_views.to_i > 0 %>
 
   <% if any_data %>
     <table>
@@ -42,7 +44,7 @@
         </tr>
       <% end %>
 
-      <% if @website_views.to_i > 0 %>
+      <% if @website_views.nil? || @website_views.to_i > 0 %>
         <tr>
           <td>
             <div class="tooltip">
@@ -50,11 +52,11 @@
               <span class="tooltiptext"><%= website_views_total_tooltip %></span>
             </div>
           </td>
-          <td><%= number_with_delimiter(@website_views, delimiter: ',') %></td>
+          <td><%= dash_or(@website_views) %></td>
         </tr>
       <% end %>
 
-      <% if @wikimedia_views.to_i > 0 %>
+      <% if @wikimedia_views.nil? || @wikimedia_views.to_i > 0 %>
         <tr>
           <td>
             <div class="tooltip">
@@ -62,7 +64,7 @@
               <span class="tooltiptext"><%= wikimedia_views_total_tooltip %></span>
             </div>
           </td>
-          <td><%= number_with_delimiter(@wikimedia_views, delimiter: ',') %></td>
+          <td><%= dash_or(@wikimedia_views) %></td>
         </tr>
       <% end %>
     </table>

--- a/app/views/shared/_wikimedia_overview.html.erb
+++ b/app/views/shared/_wikimedia_overview.html.erb
@@ -1,11 +1,13 @@
 <%# Local variables: @wa_data[Hash], @wp_data[Hash], @item_count[Int|Nil], @target[Hub|Contributor], @wikimedia_participant[Boolean] %>
 
-<% if @wa_data.present? && @wa_data.any? { |_, v| v.to_i > 0 } %>
+<%# nil = still loading (skeleton); present with values = show data; otherwise = no-data message %>
+<% if @wa_data.nil? || (@wa_data.present? && @wa_data.any? { |_, v| v.to_i > 0 }) %>
 
   <table>
     <% WikimediaAnalyticsPresenter.fields.each do |key| %>
-      <% value = @wa_data[key] %>
-      <% next unless value.to_i > 0 %>
+      <% value = @wa_data&.[](key) %>
+      <%# Skip zero-value rows when data is loaded; show all rows in skeleton mode %>
+      <% next if @wa_data && value.to_i == 0 %>
       <tr>
         <td>
           <div class="tooltip">
@@ -13,9 +15,7 @@
             <span class="tooltiptext"><%= find_tooltip(key) %></span>
           </div>
         </td>
-        <td>
-          <%= number_with_delimiter(value, delimiter: ',') %>
-        </td>
+        <td><%= dash_or(value) %></td>
       </tr>
     <% end %>
   </table>
@@ -30,7 +30,19 @@
 
 <% key = 'wikimediaReady' %>
 
-<% if @wp_data.present? && @wp_data.key?(key) %>
+<% if @wp_data.nil? %>
+  <table>
+    <tr>
+      <td>
+        <div class="tooltip">
+          <span>Wikimedia Ready</span>
+          <span class="tooltiptext"><%= wikimedia_readiness_tooltip %></span>
+        </div>
+      </td>
+      <td class="bar">—</td>
+    </tr>
+  </table>
+<% elsif @wp_data.present? && @wp_data.key?(key) %>
   <% value = @wp_data[key] %>
   <% ready_count = @item_count ? (@item_count.to_f * value.to_f).round : nil %>
 


### PR DESCRIPTION
## Summary

- The `render_async_section` placeholder on hub and contributor show pages previously rendered three blank "Loading..." blocks, hiding all section structure until GA4 data arrived. The entire page now renders its skeleton synchronously — section headings, row labels, and "—" placeholder values are visible on page load. Numbers fill in when the `sections` async fetch completes.
- Each section partial now handles `nil` instance variables (skeleton state) vs loaded data using a single code path where possible, eliminating near-duplicate skeleton/data branches.
- Added `dash_or(value)` helper to `ApplicationHelper` to consolidate the repeated `nil ? "—" : number_with_delimiter(...)` pattern.
- Fixed a pre-existing latent crash: `@website_event_totals.error?` would raise `NoMethodError` if the `website_overview_t` thread succeeded but `website_events_t` rescued to `nil`. Changed to `&.error?` safe navigation.

## How it works

- `show` actions now set `@target` (= `@hub` / `@contributor`) so `_wikimedia_overview`'s readiness link renders correctly on the skeleton pass.
- `_totals`: `@website_views` / `@wikimedia_views` are nil on skeleton pass → rows shown with "—"; after async, replaced with real values.
- `_frontend_use_metrics`: nil guard shows full skeleton table; data guard unchanged.
- `_wikimedia_overview`: single `WikimediaAnalyticsPresenter.fields` loop — nil values show "—", zero values skip, positive values render normally.
- `_metadata_completeness`: single `MetadataCompletenessPresenter.fields` loop replaces two near-identical branches.

## Test plan

- [ ] Hub show page: all four sections (Totals, DPLA Website, Wikimedia, Metadata Completeness) render their full structure immediately with "—" for every number; numbers fill in after a few seconds
- [ ] Contributor show page: same
- [ ] After async: no rows appear or disappear that shouldn't (zero-value rows correctly absent, non-zero rows correct)
- [ ] Date range filter: changing date range re-triggers async and skeleton re-renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of loading and missing data across metrics and analytics; views now distinguish “loading” vs error states.
  * Consolidated metric sections for contributor and hub pages so async sections render unified, consistent content.

* **Style / UX**
  * Unavailable or missing numeric values now display a consistent em‑dash placeholder and delimiter formatting for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->