### PR TITLE
Guard against nil rows in WebsiteEventsByContributor#parse_data

### DIFF
--- a/app/lib/website_events_by_contributor.rb
+++ b/app/lib/website_events_by_contributor.rb
@@ -51,15 +51,15 @@ class WebsiteEventsByContributor
   end
 
   def parse_data
-    return Hash.new unless response.present?
+    return Hash.new unless response.present? && response.rows.present?
     # Create Hash of data
     # e.g. "The Library" => { "Click Throughs" => 2, "Total Views" => 5 }
     data = {}
 
-    response.rows.map do |r|
+    response.rows.each do |r|
       event = r[0].split(" : ").first
       contributor = r[1]
-      count = r[2].to_i rescue 0
+      count = r[2]&.to_i || 0
 
       data[contributor] ||= { "Views" => 0, "Click Throughs" => 0 }
       data[contributor]["Click Throughs"] += count if event == "Click Through"


### PR DESCRIPTION
## Summary
- GA4 returns `nil` for `rows` on empty result sets; the guard now checks `response.rows.present?` before iterating, preventing a `NoMethodError` crash on the contributor comparison page
- Matches the existing pattern in the sibling class `WebsiteOverviewByContributor`
- Also fixes `map` → `each` (return value was unused) and replaces inline `rescue` with safe navigation

Fixes Sentry DPLA-FRONTEND-1J8.

## Test plan
- [ ] Load the contributor comparison page for a contributor with no GA4 event data for the selected date range — table should render empty rather than 500
- [ ] Load it for a contributor with data — table should render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data validation and null-value handling in website event tracking to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->