### PR TITLE
Fix contributor data regression; async GA columns; 404 guards; tooltip counts

### DIFF
--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -14,7 +14,7 @@ body, button, input, label, select, textarea {
 }
 
 .ga-loading {
-  color: #888;
+  color: #666;
 }
 
 .clear {
@@ -480,8 +480,10 @@ footer {
     border-color: #555 transparent transparent transparent;
 }
 
-/* Show the tooltip text when you mouse over the tooltip container */
-.tooltip:hover .tooltiptext {
+/* Show the tooltip text when you mouse over or focus the tooltip container */
+.tooltip:hover .tooltiptext,
+.tooltip:focus .tooltiptext,
+.tooltip:focus-within .tooltiptext {
     visibility: visible;
     opacity: 1;
 }

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -13,6 +13,10 @@ body, button, input, label, select, textarea {
   display: none;
 }
 
+.ga-loading {
+  color: #aaa;
+}
+
 .clear {
   clear: both;
 }

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -14,7 +14,7 @@ body, button, input, label, select, textarea {
 }
 
 .ga-loading {
-  color: #aaa;
+  color: #888;
 }
 
 .clear {

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class UsersController < ApplicationController
 
     def index
-      @users = current_user.hub == "All" ? User.all : 
+      @users = admin_for_all_hubs? ? User.all : 
         User.where("hub = ?", current_user.hub)
 
       redirect_to admin_user_path(current_user) unless current_user.admin
@@ -91,11 +91,17 @@ module Admin
     private
 
     def user_params
-      params.require(:user).permit(:email,
-                                   :admin,
-                                   :hub,
-                                   :password,
-                                   :password_confirmation)
+      permitted = params.require(:user).permit(:email,
+                                               :admin,
+                                               :hub,
+                                               :password,
+                                               :password_confirmation)
+      # Hub-scoped admins may only create/edit users within their own hub.
+      # Override any submitted hub value and disallow escalation to "All".
+      unless admin_for_all_hubs?
+        permitted[:hub] = current_user.hub
+      end
+      permitted
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,8 +27,10 @@ module Admin
     end
 
     def edit
-      @user = User.find(params[:id])
-      redirect_to admin_user_path(current_user) unless current_user.admin
+      unless current_user.admin
+        redirect_to admin_user_path(current_user) and return
+      end
+      @user = manageable_users.find(params[:id])
     end
 
     def create
@@ -59,7 +61,7 @@ module Admin
         redirect_to admin_user_path(current_user) and return
       end
 
-      @user = User.find(params[:id])
+      @user = manageable_users.find(params[:id])
 
       if @user.update(user_params)
         redirect_to admin_users_path
@@ -74,7 +76,7 @@ module Admin
         redirect_to admin_user_path(current_user) and return
       end
 
-      @user = User.find(params[:id])
+      @user = manageable_users.find(params[:id])
       email = @user.email
 
       if @user.destroy
@@ -92,13 +94,17 @@ module Admin
         redirect_to admin_user_path(current_user) and return
       end
 
-      @user = User.find(params[:id])
+      @user = manageable_users.find(params[:id])
       @user.send_reset_password_instructions
       flash[:notice] = "Password reset instructions sent to #{@user.email}."
       redirect_to admin_users_path
     end
 
     private
+
+    def manageable_users
+      admin_for_all_hubs? ? User.all : User.where(hub: current_user.hub)
+    end
 
     def user_params
       permitted = params.require(:user).permit(:email,

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,6 +32,11 @@ module Admin
     end
 
     def create
+      unless current_user.admin
+        flash[:alert] = "You don't have permission to create a new user."
+        redirect_to admin_user_path(current_user) and return
+      end
+
       generated_password = Devise.friendly_token.first(8)
       create_params = user_params
       create_params[:password] = generated_password
@@ -49,6 +54,11 @@ module Admin
     end
 
     def update
+      unless current_user.admin
+        flash[:alert] = "You don't have permission to edit users."
+        redirect_to admin_user_path(current_user) and return
+      end
+
       @user = User.find(params[:id])
 
       if @user.update(user_params)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,15 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def render_not_found
+    render "errors/not_found", status: :not_found, layout: "application"
+  end
+
+  def admin_for_all_hubs?
+    current_user.hub == "All"
+  end
+  helper_method :admin_for_all_hubs?
+
   def layout_by_resource
     if devise_controller?
       "devise"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_for_all_hubs?
-    current_user.hub == "All"
+    current_user.admin && current_user.hub == "All"
   end
   helper_method :admin_for_all_hubs?
 

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -300,7 +300,7 @@ class ContributorsController < ApplicationController
       threads << Thread.new { website_overview.response }
       threads << Thread.new { website_events.response }
     end
-    threads.each(&:join)
+    threads.each(&:value)
 
     mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
     wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
@@ -334,9 +334,13 @@ class ContributorsController < ApplicationController
   # Called asynchronously by the comparison table after it renders.
   #
   def contributor_ga_data
-    assign_start_and_end_dates
-
     hub_id = params[:hub_id]
+    return head :not_found unless Hub.exists?(hub_id)
+    unless current_user.hub == hub_id || admin_for_all_hubs?
+      return head :forbidden
+    end
+
+    assign_start_and_end_dates
 
     website_overview = WebsiteOverviewByContributor.build do |builder|
       builder.hub        = hub_id
@@ -353,7 +357,7 @@ class ContributorsController < ApplicationController
     [
       Thread.new { website_overview.response },
       Thread.new { website_events.response }
-    ].each(&:join)
+    ].each(&:value)
 
     overview_data = website_overview.parse_data
     events_data   = website_events.parse_data

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -10,15 +10,20 @@ class ContributorsController < ApplicationController
   include TooltipsHelper
 
   def index
+    return render_not_found unless Hub.exists?(params[:hub_id])
+
     assign_start_and_end_dates
     @hub = Hub.new(params[:hub_id], @start_date, @end_date)
 
-    unless current_user.hub == params[:hub_id] || current_user.hub == "All"
+    unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
       redirect_to hub_contributors_path(current_user.hub)
     end
   end
 
   def show
+    return render_not_found unless Hub.exists?(params[:hub_id])
+    return render_not_found unless Hub.contributor?(params[:hub_id], params[:id])
+
     assign_start_and_end_dates
     @contributor = Contributor.new(params[:id],
                                    params[:hub_id],
@@ -29,7 +34,7 @@ class ContributorsController < ApplicationController
     @item_count = Hub.item_count(params[:hub_id], params[:id])
     @target     = @contributor
 
-    unless current_user.hub == params[:hub_id] || current_user.hub == "All"
+    unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
       redirect_to hub_path(current_user.hub)
     end
   end
@@ -43,7 +48,7 @@ class ContributorsController < ApplicationController
     assign_start_and_end_dates
 
     hub_id     = params[:hub_id]
-    contrib_id = params[:contributor_id]
+    contrib_id = params[:id]
     all_start  = min_date
     all_end    = max_date
     end_date   = @end_date
@@ -116,14 +121,14 @@ class ContributorsController < ApplicationController
 
     @website_overview = WebsiteOverview.build do |builder|
       builder.hub         = params[:hub_id]
-      builder.contributor = params[:contributor_id]
+      builder.contributor = params[:id]
       builder.start_date  = @start_date
       builder.end_date    = @end_date
     end
 
     @website_event_totals = WebsiteEventTotals.build do |builder|
       builder.hub         = params[:hub_id]
-      builder.contributor = params[:contributor_id]
+      builder.contributor = params[:id]
       builder.start_date  = @start_date
       builder.end_date    = @end_date
     end
@@ -136,7 +141,7 @@ class ContributorsController < ApplicationController
 
     @api_overview = ApiOverview.build do |builder|
       builder.hub = params[:hub_id]
-      builder.contributor = params[:contributor_id]
+      builder.contributor = params[:id]
       builder.start_date = @start_date
       builder.end_date = @end_date
     end
@@ -147,18 +152,18 @@ class ContributorsController < ApplicationController
   def contributor_bws_overview
     assign_start_and_end_dates
 
-    @bws_item_count = Hub.bws_item_count(params[:hub_id], params[:contributor_id])
+    @bws_item_count = Hub.bws_item_count(params[:hub_id], params[:id])
 
     @bws_overview = BwsOverview.build do |builder|
       builder.hub = params[:hub_id]
-      builder.contributor = params[:contributor_id]
+      builder.contributor = params[:id]
       builder.start_date = @start_date
       builder.end_date = @end_date
     end
 
     @bws_event_totals = BwsEventTotals.build do |builder|
       builder.hub = params[:hub_id]
-      builder.contributor = params[:contributor_id]
+      builder.contributor = params[:id]
       builder.start_date = @start_date
       builder.end_date = @end_date
     end
@@ -167,19 +172,19 @@ class ContributorsController < ApplicationController
   end
 
   def contributor_item_count
-    @item_count = Hub.item_count(params[:hub_id], params[:contributor_id])
+    @item_count = Hub.item_count(params[:hub_id], params[:id])
     render partial: "shared/item_count"
   end
 
   def contributor_totals
-    @item_count = Hub.item_count(params[:hub_id], params[:contributor_id])
+    @item_count = Hub.item_count(params[:hub_id], params[:id])
 
     results = [
       Thread.new {
         begin
           WebsiteOverview.build do |b|
             b.hub         = params[:hub_id]
-            b.contributor = params[:contributor_id]
+            b.contributor = params[:id]
             b.start_date  = min_date
             b.end_date    = max_date
           end.events
@@ -193,7 +198,7 @@ class ContributorsController < ApplicationController
           WikimediaAnalyticsPresenter.new(
             start_month: min_date.strftime("%Y-%m"),
             end_month:   max_date.strftime("%Y-%m")
-          ).contributor(params[:hub_id], params[:contributor_id])["Page views"]
+          ).contributor(params[:hub_id], params[:id])["Page views"]
         rescue => e
           Rails.logger.error(e)
           nil
@@ -212,12 +217,12 @@ class ContributorsController < ApplicationController
 
     metadata_completeness = MetadataCompleteness.build do |builder|
       builder.hub = params[:hub_id]
-      builder.contributor = params[:contributor_id]
+      builder.contributor = params[:id]
       builder.end_date = @end_date
     end
 
     mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
-    @mc_data = mc_presenter.contributor(params[:hub_id], params[:contributor_id])
+    @mc_data = mc_presenter.contributor(params[:hub_id], params[:id])
     render partial: "shared/metadata_completeness"
   end
 
@@ -226,22 +231,22 @@ class ContributorsController < ApplicationController
 
     metadata_completeness = MetadataCompleteness.build do |builder|
       builder.hub         = params[:hub_id]
-      builder.contributor = params[:contributor_id]
+      builder.contributor = params[:id]
       builder.end_date    = @end_date
     end
 
     wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
-    @wp_data = wp_presenter.contributor(params[:hub_id], params[:contributor_id])
+    @wp_data = wp_presenter.contributor(params[:hub_id], params[:id])
 
     wa_presenter = WikimediaAnalyticsPresenter.new(
       start_month: @start_date.strftime("%Y-%m"),
       end_month:   @end_date.strftime("%Y-%m")
     )
-    @wa_data = wa_presenter.contributor(params[:hub_id], params[:contributor_id])
+    @wa_data = wa_presenter.contributor(params[:hub_id], params[:id])
 
-    @item_count            = Hub.item_count(params[:hub_id], params[:contributor_id])
-    @wikimedia_participant = WikimediaParticipant.participant?(params[:hub_id], params[:contributor_id])
-    @target                = Contributor.new(params[:contributor_id],
+    @item_count            = Hub.item_count(params[:hub_id], params[:id])
+    @wikimedia_participant = WikimediaParticipant.participant?(params[:hub_id], params[:id])
+    @target                = Contributor.new(params[:id],
                                              params[:hub_id],
                                              @start_date,
                                              @end_date)
@@ -251,19 +256,6 @@ class ContributorsController < ApplicationController
 
   def contributor_comparison
     assign_start_and_end_dates
-
-    # Build objects first — no network calls yet.
-    website_overview = WebsiteOverviewByContributor.build do |builder|
-      builder.hub = params[:hub_id]
-      builder.start_date = @start_date
-      builder.end_date = @end_date
-    end
-
-    website_events = WebsiteEventsByContributor.build do |builder|
-      builder.hub = params[:hub_id]
-      builder.start_date = @start_date
-      builder.end_date = @end_date
-    end
 
     bws_overview = BwsOverviewByContributor.build do |builder|
       builder.hub = params[:hub_id]
@@ -288,16 +280,27 @@ class ContributorsController < ApplicationController
       builder.end_date = @end_date
     end
 
-    # Fire GA4/S3 calls concurrently; item counts come from the local cache.
     hub_id = params[:hub_id]
     contributors_item_count = Hub.contributors_item_count(hub_id)
     bws_item_count          = Hub.contributors_bws_item_count(hub_id)
 
-    [
-      Thread.new { website_overview.response },
-      Thread.new { website_events.response },
-      Thread.new { metadata_completeness.contributor_csv },
-    ].each(&:join)
+    # For HTML the GA website columns load async via contributor_ga_data; pass nil
+    # so the table renders immediately from fast S3/DB caches.
+    # For CSV exports, prefetch GA data so the download is complete.
+    website_overview = nil
+    website_events   = nil
+    threads = [Thread.new { metadata_completeness.contributor_csv }]
+    if request.format.csv?
+      website_overview = WebsiteOverviewByContributor.build do |builder|
+        builder.hub = params[:hub_id]; builder.start_date = @start_date; builder.end_date = @end_date
+      end
+      website_events = WebsiteEventsByContributor.build do |builder|
+        builder.hub = params[:hub_id]; builder.start_date = @start_date; builder.end_date = @end_date
+      end
+      threads << Thread.new { website_overview.response }
+      threads << Thread.new { website_events.response }
+    end
+    threads.each(&:join)
 
     mc_presenter = MetadataCompletenessPresenter.new(metadata_completeness)
     wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
@@ -310,7 +313,7 @@ class ContributorsController < ApplicationController
       builder.hub = params[:hub_id]
       builder.contributors_item_count = contributors_item_count
       builder.website_overview = website_overview
-      builder.website_events = website_events
+      builder.website_events   = website_events
       builder.bws_item_count = bws_item_count
       builder.bws_overview = bws_overview
       builder.bws_events = bws_events
@@ -324,5 +327,53 @@ class ContributorsController < ApplicationController
       format.html { render partial: "shared/contributor_comparison" }
       format.csv { send_data @contributor_comparison.to_csv }
     end
+  end
+
+  ##
+  # Returns GA website metrics for all contributors in a hub as JSON.
+  # Called asynchronously by the comparison table after it renders.
+  #
+  def contributor_ga_data
+    assign_start_and_end_dates
+
+    hub_id = params[:hub_id]
+
+    website_overview = WebsiteOverviewByContributor.build do |builder|
+      builder.hub        = hub_id
+      builder.start_date = @start_date
+      builder.end_date   = @end_date
+    end
+
+    website_events = WebsiteEventsByContributor.build do |builder|
+      builder.hub        = hub_id
+      builder.start_date = @start_date
+      builder.end_date   = @end_date
+    end
+
+    [
+      Thread.new { website_overview.response },
+      Thread.new { website_events.response }
+    ].each(&:join)
+
+    overview_data = website_overview.parse_data
+    events_data   = website_events.parse_data
+
+    result = Hub.contributors_item_count(hub_id).each_with_object({}) do |c, hash|
+      contributor = c["term"]
+      ga_key      = contributor[0, GaResponseBuilder::GA4_EVENT_NAME_MAX_LENGTH]
+      ov          = overview_data[ga_key] || {}
+      ev          = events_data[ga_key]   || {}
+      hash[contributor] = {
+        "views"          => ev["Views"]          || 0,
+        "click-throughs" => ev["Click Throughs"] || 0,
+        "sessions"       => ov["Sessions"]       || 0,
+        "users"          => ov["Users"]          || 0
+      }
+    end
+
+    render json: result
+  rescue => e
+    Rails.logger.error(e)
+    render json: {}, status: :service_unavailable
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,7 +18,7 @@ class EventsController < ApplicationController
 
     @target = params[:contributor_id] ? @contributor : @hub
 
-    unless current_user.hub == params[:hub_id] || current_user.hub == "All"
+    unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
       redirect_to hub_path(current_user.hub)
     end
   end

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -10,13 +10,15 @@ class HubsController < ApplicationController
   include TooltipsHelper
 
   def index
+    return redirect_to(hub_path(current_user.hub)) unless admin_for_all_hubs?
+
     assign_start_and_end_dates
     @hubs = Hub.all_with_counts
-    redirect_to hub_path(current_user.hub) unless admin_for_all_hubs?
   end
 
   def show
     return render_not_found unless Hub.exists?(params[:id])
+    return redirect_to(hub_path(current_user.hub)) unless current_user.hub == params[:id] || admin_for_all_hubs?
 
     assign_start_and_end_dates
     @hub = Hub.new(params[:id], @start_date, @end_date)
@@ -30,10 +32,6 @@ class HubsController < ApplicationController
     @item_count        = Hub.item_count(params[:id])
     @contributor_count = Hub.contributor_count(params[:id])
     @target            = @hub
-
-    unless current_user.hub == params[:id] || admin_for_all_hubs?
-      redirect_to hub_path(current_user.hub)
-    end
   end
 
   ##

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -12,10 +12,12 @@ class HubsController < ApplicationController
   def index
     assign_start_and_end_dates
     @hubs = Hub.all_with_counts
-    redirect_to hub_path(current_user.hub) unless current_user.hub == "All"
+    redirect_to hub_path(current_user.hub) unless admin_for_all_hubs?
   end
 
   def show
+    return render_not_found unless Hub.exists?(params[:id])
+
     assign_start_and_end_dates
     @hub = Hub.new(params[:id], @start_date, @end_date)
 
@@ -29,7 +31,7 @@ class HubsController < ApplicationController
     @contributor_count = Hub.contributor_count(params[:id])
     @target            = @hub
 
-    unless current_user.hub == params[:id] || current_user.hub == "All"
+    unless current_user.hub == params[:id] || admin_for_all_hubs?
       redirect_to hub_path(current_user.hub)
     end
   end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -18,7 +18,7 @@ class LocationsController < ApplicationController
 
     @target = params[:contributor_id] ? @contributor : @hub
 
-    unless current_user.hub == params[:hub_id] || current_user.hub == "All"
+    unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
       redirect_to hub_path(current_user.hub)
     end
   end

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -20,7 +20,7 @@ class TimelinesController < ApplicationController
 
     @id = params[:id]
 
-    unless current_user.hub == params[:hub_id] || current_user.hub == "All"
+    unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
       redirect_to hub_path(current_user.hub)
     end
   end

--- a/app/controllers/wikimedia_preparations_controller.rb
+++ b/app/controllers/wikimedia_preparations_controller.rb
@@ -23,7 +23,7 @@ class WikimediaPreparationsController < ApplicationController
 
     @id = params[:id]
 
-    unless current_user.hub == params[:hub_id] || current_user.hub == "All"
+    unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
       redirect_to hub_path(current_user.hub)
     end
   end

--- a/app/helpers/metadata_completeness_helper.rb
+++ b/app/helpers/metadata_completeness_helper.rb
@@ -9,4 +9,23 @@ module MetadataCompletenessHelper
   def percentage_class(num)
     "value-#{(num.to_f * 100).round.to_s}"
   end
+
+  ##
+  # Renders a percentage wrapped in a tooltip whose body shows the absolute count.
+  # When item_count is nil the tooltip is omitted and a bare percentage is returned.
+  #
+  # @param value      [Float, nil]  the fractional value (e.g. 0.41)
+  # @param item_count [Integer, nil] the total number of items
+  # @return [ActiveSupport::SafeBuffer]
+  def render_percentage_with_count(value, item_count)
+    pct = render_percentage(value)
+    return pct if item_count.nil? || item_count.to_i == 0 || value.nil?
+    abs = (value.to_f * item_count.to_i).round
+    content_tag(:div, class: "tooltip") do
+      content_tag(:span, pct) +
+        content_tag(:span,
+                    "#{number_with_delimiter(abs)} of #{number_with_delimiter(item_count)} items",
+                    class: "tooltiptext")
+    end
+  end
 end

--- a/app/helpers/metadata_completeness_helper.rb
+++ b/app/helpers/metadata_completeness_helper.rb
@@ -21,7 +21,7 @@ module MetadataCompletenessHelper
     pct = render_percentage(value)
     return pct if item_count.nil? || item_count.to_i == 0 || value.nil?
     abs = (value.to_f * item_count.to_i).round
-    content_tag(:div, class: "tooltip") do
+    content_tag(:div, class: "tooltip", tabindex: 0) do
       content_tag(:span, pct) +
         content_tag(:span,
                     "#{number_with_delimiter(abs)} of #{number_with_delimiter(item_count)} items",

--- a/app/lib/contributor_comparison.rb
+++ b/app/lib/contributor_comparison.rb
@@ -193,11 +193,11 @@ class ContributorComparison
   private
 
   def frontend_use_by_contributor
-    @frontend_use_by_contributor ||= @website_overview.parse_data
+    @frontend_use_by_contributor ||= @website_overview&.parse_data || {}
   end
 
   def frontend_events_by_contributor
-    @frontend_events_by_contributor ||= @website_events.parse_data
+    @frontend_events_by_contributor ||= @website_events&.parse_data || {}
   end
 
   def bws_use_by_contributor

--- a/app/lib/hub.rb
+++ b/app/lib/hub.rb
@@ -37,6 +37,14 @@ class Hub
   # @param hub [String]
   # @return [Array<String>] sorted contributor names
   #
+  def self.exists?(hub)
+    HubStats.fetch.dig("hubs", hub) != nil
+  end
+
+  def self.contributor?(hub, contributor)
+    HubStats.fetch.dig("hubs", hub, "contributors", contributor) != nil
+  end
+
   def self.contributors(hub)
     (HubStats.fetch.dig("hubs", hub, "contributors") || {}).keys.sort
   end

--- a/app/lib/website_events_by_contributor.rb
+++ b/app/lib/website_events_by_contributor.rb
@@ -51,15 +51,15 @@ class WebsiteEventsByContributor
   end
 
   def parse_data
-    return Hash.new unless response.present?
+    return Hash.new unless response.present? && response.rows.present?
     # Create Hash of data
     # e.g. "The Library" => { "Click Throughs" => 2, "Total Views" => 5 }
     data = {}
 
-    response.rows.map do |r|
+    response.rows.each do |r|
       event = r[0].split(" : ").first
       contributor = r[1]
-      count = r[2].to_i rescue 0
+      count = r[2]&.to_i || 0
 
       data[contributor] ||= { "Views" => 0, "Click Throughs" => 0 }
       data[contributor]["Click Throughs"] += count if event == "Click Through"

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -21,7 +21,7 @@
 
     <div>
       <%= f.label :hub %>
-      <% if current_user.hub == "All" %>
+      <% if admin_for_all_hubs? %>
           <%= f.select :hub, Hub.all.unshift("All") %>
       <% else %>
           <%= f.select :hub, [current_user.hub] %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -26,7 +26,7 @@
 
     <div>
       <%= f.label :hub %>
-      <% if current_user.hub == "All" %>
+      <% if admin_for_all_hubs? %>
           <%= f.select :hub, Hub.all.unshift("All") %>
       <% else %>
           <%= f.select :hub, [current_user.hub] %>

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -29,9 +29,9 @@
           var contributor = td.dataset.gaContributor;
           var field       = td.dataset.gaField;
           var row         = data[contributor];
+          td.classList.remove("ga-loading");
           if (row && row[field] !== undefined) {
             td.textContent = row[field].toLocaleString();
-            td.classList.remove("ga-loading");
           }
         });
       })

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -14,6 +14,35 @@
       });
     }
   }
+
+  document.addEventListener("contributor-comparison-loaded", function() {
+    var table = document.getElementById("comparison");
+    if (!table) return;
+    var gaUrl = table.dataset.gaUrl;
+    if (!gaUrl) return;
+
+    var gaCells = document.querySelectorAll("[data-ga-contributor]");
+    fetch(gaUrl, { credentials: "same-origin", headers: { "Accept": "application/json" } })
+      .then(function(r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function(data) {
+        gaCells.forEach(function(td) {
+          var contributor = td.dataset.gaContributor;
+          var field       = td.dataset.gaField;
+          var row         = data[contributor];
+          if (row && row[field] !== undefined) {
+            td.textContent = row[field].toLocaleString();
+            td.classList.remove("ga-loading");
+          }
+        });
+      })
+      .catch(function(err) {
+        console.warn("GA data fetch failed:", err);
+        gaCells.forEach(function(td) {
+          td.classList.remove("ga-loading");
+          td.textContent = "—";
+        });
+      });
+  });
 </script>
 
 <div class="heading">
@@ -31,7 +60,7 @@
   <h2>Contributors</h2>
 
   <%= render_async_section contributor_comparison_path({ hub_id: params[:hub_id] }.merge(date_opts)),
-        event_name: 'contributor-comparison-loaded' do %>
+                           event_name: "contributor-comparison-loaded" do %>
     <div>Loading...</div>
   <% end %>
 

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,13 @@
+<main>
+  <div class="heading">
+    <h1>Page Not Found</h1>
+  </div>
+  <div class="error-body">
+    <p class="error-message">
+      The hub or contributor you requested could not be found.
+    </p>
+    <p class="error-note">
+      Check the URL for typos, or <%= link_to "return to the hub list", root_path %>.
+    </p>
+  </div>
+</main>

--- a/app/views/shared/_contributor_comparison.html.erb
+++ b/app/views/shared/_contributor_comparison.html.erb
@@ -133,7 +133,8 @@
 </div>
 
 <div class="comparison-table-wrapper">
-<table id='comparison'>
+<table id='comparison'
+       data-ga-url="<%= contributor_ga_data_path({ hub_id: params[:hub_id] }.merge(date_opts)) %>">
   <thead>
     <tr>
       <th>Contributor</th>
@@ -173,18 +174,18 @@
           <%= link_to contributor, { controller: :contributors, action: :show,
                                      hub_id: params[:hub_id], id: contributor }.merge(date_opts) %>
         </td>
-        <td class="website-view">
-          <%= totals["Website"]["Views"] || 0 %>
-        </td>
-        <td class="click-through">
-          <%= totals["Website"]["Click Throughs"] || 0 %>
-        </td>
-        <td class="website-session">
-          <%= totals["Website"]["Sessions"] || 0 %>
-        </td>
-        <td class="website-user">
-          <%= totals["Website"]["Users"] || 0 %>
-        </td>
+        <td class="website-view ga-loading"
+            data-ga-contributor="<%= contributor %>"
+            data-ga-field="views">—</td>
+        <td class="click-through ga-loading"
+            data-ga-contributor="<%= contributor %>"
+            data-ga-field="click-throughs">—</td>
+        <td class="website-session ga-loading"
+            data-ga-contributor="<%= contributor %>"
+            data-ga-field="sessions">—</td>
+        <td class="website-user ga-loading"
+            data-ga-contributor="<%= contributor %>"
+            data-ga-field="users">—</td>
         <% if bws_data_for_date_range? %>
           <td class="bws-item-count">
             <%= totals["BWS"]["ItemCount"] || 0 %>
@@ -213,7 +214,7 @@
         <% WikimediaPreparationsPresenter.fields.each do |field| %>
           <% value = totals["WikimediaPreparations"][field] %>
           <td class="<%= field %> <%= percentage_class(value) %>">
-            <%= render_percentage(value) %>
+            <%= render_percentage_with_count(value, totals["ItemCount"]) %>
           </td>
         <% end %>
         <% WikimediaAnalyticsPresenter.fields.each do |field| %>
@@ -226,7 +227,7 @@
           <% unless field == "count" %>
             <% value = totals["MetadataCompleteness"][field] %>
             <td class="<%= field %> <%= percentage_class(value) %>">
-              <%= render_percentage(value) %>
+              <%= render_percentage_with_count(value, totals["ItemCount"]) %>
             </td>
           <% end %>
         <% end %>

--- a/app/views/shared/_metadata_completeness.html.erb
+++ b/app/views/shared/_metadata_completeness.html.erb
@@ -22,7 +22,7 @@
           </div>
         </td>
         <td class="bar <%= percentage_class(value) unless value.nil? %>">
-          <%= value.nil? ? "—" : render_percentage(value) %>
+          <%= value.nil? ? "—" : render_percentage_with_count(value, @item_count) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,6 +1,6 @@
 <nav>
   <ul>
-    <% if current_user.hub == "All" %>
+    <% if admin_for_all_hubs? %>
         <li>
           <%= link_to "Hubs", hubs_path %>
         </li>

--- a/app/views/shared/_sub_navigation.html.erb
+++ b/app/views/shared/_sub_navigation.html.erb
@@ -1,6 +1,6 @@
 <%# Local variables: hub [Hub] %>
 
-<% if current_user.hub == "All" %>
+<% if admin_for_all_hubs? %>
   <div class="submenu">
     <nav>
       <ul>

--- a/app/views/shared/_wikimedia_readiness.html.erb
+++ b/app/views/shared/_wikimedia_readiness.html.erb
@@ -27,7 +27,7 @@
           <tr>
             <td><%= key.titleize %></td>
             <td class="bar <%= percentage_class(value) %>">
-              <%= render_percentage(value) %>
+              <%= render_percentage_with_count(value, @item_count) %>
             </td>
           </tr>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
   get :api_search_terms, controller: :search_terms
   get :website_search_terms, controller: :search_terms
   get :contributor_comparison, controller: :contributors
-  get :contributor_ga_data,   controller: :contributors
+  get :contributor_ga_data,   controller: :contributors, defaults: { format: :json }
 
   root 'hubs#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
   get :api_search_terms, controller: :search_terms
   get :website_search_terms, controller: :search_terms
   get :contributor_comparison, controller: :contributors
+  get :contributor_ga_data,   controller: :contributors
 
   root 'hubs#index'
 end


### PR DESCRIPTION
## Summary

- **Regression fix**: All contributor pages were showing no data since #263. Root cause: contributor member actions (sections, website overview, etc.) were reading `params[:contributor_id]`, but Rails puts the contributor ID in `params[:id]` for member routes — `params[:contributor_id]` is only populated for routes nested *inside* contributors (events, timelines, etc.).
- **Async GA columns**: Contributor comparison table now renders immediately from fast S3/DB caches, with the four GA columns (Item Views, Click Throughs, Sessions, Users) filling in asynchronously via a new `contributor_ga_data` JSON endpoint after the table loads. CSV downloads still fetch GA data synchronously before responding.
- **404 for unknown paths**: Navigating to an unknown hub or contributor URL now returns a proper 404 page instead of erroring.
- **Hub-scoped admin user creation**: Server-side guard ensures hub-scoped admins can only create/edit users within their own hub; submitted hub values are overridden server-side.
- **Percentage hover tooltips**: All percentage cells now show absolute counts on hover (e.g. "41 of 1,890 items") in the comparison table and contributor/hub detail pages.
- **Cleanup**: Extract `admin_for_all_hubs?` helper to `ApplicationController` (replaces 14 scattered `current_user.hub == "All"` checks); add `Hub.exists?` / `Hub.contributor?` for O(1) lookups; add `.ga-loading` CSS class.

## Test plan

- [ ] Visit a contributor page (e.g. `/hubs/Heartland Hub/contributors/Drake University`) — data sections should load and populate
- [ ] Visit `/hubs/Typo%20Hub` — should render 404
- [ ] Visit `/hubs/Heartland%20Hub/contributors/NotAContributor` — should render 404
- [ ] Visit the contributors index for a hub — table renders immediately with S3/DB columns; GA columns populate async after ~5–10s
- [ ] Download CSV from contributor comparison — all columns including GA should be populated
- [ ] Hover over a percentage value — tooltip shows absolute count
- [ ] As a hub-scoped admin, attempt to create a user for a different hub — hub should be overridden to own hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous loading of Google Analytics metrics in contributor comparisons with loading indicators and a new JSON endpoint
  * Item-count tooltips for metadata completeness and Wikimedia readiness percentages
  * Added a “Page Not Found” error page
  * Minor styling for GA loading state

* **Bug Fixes**
  * Improved hub/contributor existence and access validation
  * Prevented non-admin hub escalation
  * Safer handling of missing analytics data

* **Chores**
  * Centralized admin-for-all-hubs predicate and exposed it to views
<!-- end of auto-generated comment: release notes by coderabbit.ai -->