### PR TITLE
fix: use selected date range for DPLA Website section on contributor page

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -62,9 +62,11 @@ class ContributorsController < ApplicationController
       Rails.logger.error(e); nil
     end
     website_overview_t = Thread.new do
-      WebsiteOverview.build { |b|
+      overview = WebsiteOverview.build { |b|
         b.hub = hub_id; b.contributor = contrib_id; b.start_date = @start_date; b.end_date = @end_date
       }
+      overview.response
+      overview
     rescue => e
       Rails.logger.error(e); nil
     end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -54,13 +54,6 @@ class ContributorsController < ApplicationController
     end_date   = @end_date
 
     @item_count = Hub.item_count(hub_id, contrib_id)
-    website_views_t = Thread.new do
-      WebsiteOverview.build { |b|
-        b.hub = hub_id; b.contributor = contrib_id; b.start_date = all_start; b.end_date = all_end
-      }.events
-    rescue => e
-      Rails.logger.error(e); nil
-    end
     wiki_views_t = Thread.new do
       WikimediaAnalyticsPresenter.new(
         start_month: all_start.strftime("%Y-%m"), end_month: all_end.strftime("%Y-%m")
@@ -70,14 +63,14 @@ class ContributorsController < ApplicationController
     end
     website_overview_t = Thread.new do
       WebsiteOverview.build { |b|
-        b.hub = hub_id; b.contributor = contrib_id; b.start_date = all_start; b.end_date = all_end
+        b.hub = hub_id; b.contributor = contrib_id; b.start_date = @start_date; b.end_date = @end_date
       }
     rescue => e
       Rails.logger.error(e); nil
     end
     website_events_t = Thread.new do
       WebsiteEventTotals.build { |b|
-        b.hub = hub_id; b.contributor = contrib_id; b.start_date = all_start; b.end_date = all_end
+        b.hub = hub_id; b.contributor = contrib_id; b.start_date = @start_date; b.end_date = @end_date
       }
     rescue => e
       Rails.logger.error(e); nil
@@ -98,12 +91,12 @@ class ContributorsController < ApplicationController
       Rails.logger.error(e); {}
     end
 
-    [website_views_t, wiki_views_t,
+    [wiki_views_t,
      website_overview_t, website_events_t, mc_thread].each(&:join)
 
     mc_data = mc_thread.value || {}
 
-    @website_views        = website_views_t.value
+    @website_views        = website_overview_t.value&.events
     @wikimedia_views      = wiki_views_t.value
     @website_overview     = website_overview_t.value
     @website_event_totals = website_events_t.value


### PR DESCRIPTION
## Summary

- The `sections` endpoint was querying `WebsiteOverview` and `WebsiteEventTotals` using `all_start`/`all_end` (min_date → today) instead of the user-selected `@start_date`/`@end_date`.
- For the all-time date range, GA4 samples small contributors to zero, so contributors with real traffic (visible in the comparison table) showed "No activity recorded" on their detail page.
- Fix: pass `@start_date`/`@end_date` to both queries — consistent with the date filter shown in the UI and with how the comparison table's `contributor_ga_data` endpoint queries GA4.
- Bonus: removes the redundant `website_views_t` thread, which was building an identical `WebsiteOverview` to `website_overview_t`; `@website_views` now derives from `website_overview_t.value&.events` instead.

## Root cause

This was a latent design issue masked by the `params[:contributor_id]` bug fixed in #265. When `contrib_id` was nil, no contributor filter was applied to the all-time query — the hub-level totals showed something. Once `contrib_id` was correctly set to `"Drake University"`, GA4 applied the contributor filter over 8 years of data and sampled the small contributor to zero.

## Test plan

- [ ] Visit a contributor page for a hub that has data in the comparison table — the "DPLA Website (dp.la)" section should now show matching counts for the selected month
- [ ] Drake University / Heartland Hub: comparison table shows 3 item views, 7 click throughs, 5 sessions, 5 users for April 2026 — the overview page should show the same values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal processing and simplified background handling for website metrics; date handling streamlined. No changes to user-facing behavior or displayed data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->