### PR TITLE
Show contributor skeleton table immediately while comparison data loads

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -12,12 +12,17 @@ class ContributorsController < ApplicationController
   def index
     return render_not_found unless Hub.exists?(params[:hub_id])
 
+    unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
+      return redirect_to hub_contributors_path(current_user.hub)
+    end
+
     assign_start_and_end_dates
     @hub = Hub.new(params[:hub_id], @start_date, @end_date)
-    @contributors_item_count = Hub.contributors_item_count(params[:hub_id])
-
-    unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
-      redirect_to hub_contributors_path(current_user.hub)
+    begin
+      @contributors_item_count = Hub.contributors_item_count(params[:hub_id])
+    rescue => e
+      Rails.logger.error(e)
+      @contributors_item_count = []
     end
   end
 

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -14,6 +14,7 @@ class ContributorsController < ApplicationController
 
     assign_start_and_end_dates
     @hub = Hub.new(params[:hub_id], @start_date, @end_date)
+    @contributors_item_count = Hub.contributors_item_count(params[:hub_id])
 
     unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
       redirect_to hub_contributors_path(current_user.hub)

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -61,7 +61,23 @@
 
   <%= render_async_section contributor_comparison_path({ hub_id: params[:hub_id] }.merge(date_opts)),
                            event_name: "contributor-comparison-loaded" do %>
-    <div>Loading...</div>
+    <table>
+      <thead>
+        <tr>
+          <th>Contributor</th>
+          <th colspan="99"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @contributors_item_count.each do |c| %>
+          <tr>
+            <td><%= link_to c["term"], hub_contributor_path(params[:hub_id], c["term"], date_opts) %></td>
+            <%# colspan spans all data columns; exact count varies by hub (BWS, Wikimedia, API, etc.) %>
+            <td colspan="99">—</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   <% end %>
 
 </main>


### PR DESCRIPTION
## Summary

- Pre-loads contributor names (fast S3-cached via `Hub.contributors_item_count`) in the `index` action so the `render_async_section` placeholder renders a real skeleton table with contributor links instead of plain "Loading..."
- GA-sourced data columns (Item Views, Click Throughs, Sessions, Users) still fill in asynchronously after the comparison table fully loads
- Uses `hub_contributor_path` named route helper in the skeleton rows

## Test plan

- [ ] Visit the Contributors index page for any hub — skeleton table with contributor names and `—` placeholders should appear immediately
- [ ] Verify the full comparison table replaces the skeleton once the async load completes
- [ ] Confirm contributor name links in the skeleton navigate correctly
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contributors page now shows a structured table with contributor rows and interactive contributor links immediately on load, replacing the static loading placeholder.

* **Bug Fixes / Improvements**
  * Improved error handling so contributor counts fail gracefully (shows empty results instead of errors).
  * Unauthorized users are redirected earlier to the appropriate hub view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->