### PR TITLE
Redirect and show alert when end date is before start date

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,11 +19,7 @@ class ApplicationController < ActionController::Base
     end_d   = Date.parse("#{params[:end_date]}-01")   rescue nil
     return unless start_d && end_d && end_d < start_d
 
-    corrected = request.query_parameters.merge(
-      "start_date" => params[:end_date],
-      "end_date"   => params[:start_date]
-    )
-    redirect_to "#{request.path}?#{corrected.to_query}",
+    redirect_to params.to_unsafe_h.merge(start_date: params[:end_date], end_date: params[:start_date]),
                 flash: { alert: "End date was before start date — dates have been swapped." }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,30 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
   before_action :authenticate_user!
+  before_action :redirect_inverted_date_range
   layout :layout_by_resource
 
   rescue_from Google::Apis::Error, Signet::AuthorizationError, Faraday::Error,
               Timeout::Error, with: :handle_service_error
 
   private
+
+  def redirect_inverted_date_range
+    return if request.xhr?
+    return unless params[:start_date] =~ /\A\d{4}-\d{2}\z/ &&
+                  params[:end_date]   =~ /\A\d{4}-\d{2}\z/
+
+    start_d = Date.parse("#{params[:start_date]}-01") rescue nil
+    end_d   = Date.parse("#{params[:end_date]}-01")   rescue nil
+    return unless start_d && end_d && end_d < start_d
+
+    corrected = request.query_parameters.merge(
+      "start_date" => params[:end_date],
+      "end_date"   => params[:start_date]
+    )
+    redirect_to "#{request.path}?#{corrected.to_query}",
+                flash: { alert: "End date was before start date — dates have been swapped." }
+  end
 
   def render_not_found
     render "errors/not_found", status: :not_found, layout: "application"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,13 @@ class ApplicationController < ActionController::Base
     return unless params[:start_date] =~ /\A\d{4}-\d{2}\z/ &&
                   params[:end_date]   =~ /\A\d{4}-\d{2}\z/
 
-    start_d = Date.parse("#{params[:start_date]}-01") rescue nil
-    end_d   = Date.parse("#{params[:end_date]}-01")   rescue nil
-    return unless start_d && end_d && end_d < start_d
+    begin
+      start_d = Date.strptime("#{params[:start_date]}-01", "%Y-%m-%d")
+      end_d   = Date.strptime("#{params[:end_date]}-01", "%Y-%m-%d")
+    rescue ArgumentError
+      return
+    end
+    return unless end_d < start_d
 
     redirect_to params.to_unsafe_h.merge(start_date: params[:end_date], end_date: params[:start_date]),
                 flash: { alert: "End date was before start date — dates have been swapped." }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,11 @@ class ApplicationController < ActionController::Base
     end
     return unless end_d < start_d
 
-    redirect_to params.to_unsafe_h.merge(start_date: params[:end_date], end_date: params[:start_date]),
+    swapped_query = request.query_parameters.merge(
+      "start_date" => params[:end_date],
+      "end_date"   => params[:start_date]
+    )
+    redirect_to "#{request.path}?#{swapped_query.to_query}",
                 flash: { alert: "End date was before start date — dates have been swapped." }
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   private
 
   def redirect_inverted_date_range
-    return unless request.get?
+    return unless request.get? || request.head?
     return if request.xhr?
     return unless params[:start_date] =~ /\A\d{4}-\d{2}\z/ &&
                   params[:end_date]   =~ /\A\d{4}-\d{2}\z/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   private
 
   def redirect_inverted_date_range
+    return unless request.get?
     return if request.xhr?
     return unless params[:start_date] =~ /\A\d{4}-\d{2}\z/ &&
                   params[:end_date]   =~ /\A\d{4}-\d{2}\z/

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,10 +3,6 @@
 
   <div class="clear" />
 
-  <% if flash[:notice] %>
-    <div class="notice"><%= flash[:notice] %></div>
-  <% end %>
-
   <div style="margin-bottom: 1.5em; padding: 1em; border: 1px solid #e9dec8; border-radius: 3px; background: #fdf8f0;">
     <strong>Wikimedia Cache</strong>
     <%= button_to "Rebuild Wikimedia Cache",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,13 @@
       <%= render partial: "shared/navigation" %>
     </header>
 
+    <% if flash[:alert] %>
+      <div class="alert-banner" role="alert"><%= flash[:alert] %></div>
+    <% end %>
+    <% if flash[:notice] %>
+      <div class="alert-banner" role="status"><%= flash[:notice] %></div>
+    <% end %>
+
     <%= yield %>
 
     <footer>


### PR DESCRIPTION
## Summary

- Adds a `before_action :redirect_inverted_date_range` to `ApplicationController` that detects when `end_date < start_date` in URL params
- Redirects to the same page with dates swapped, showing a flash alert: *"End date was before start date — dates have been swapped."*
- Adds flash rendering to `application.html.erb` using the existing `.alert-banner` CSS class
- Skips the redirect for XHR/Ajax requests (async section loads), and only runs when both params match `YYYY-MM` format

Previously the app silently corrected to today's date with no user feedback.

## Test plan

- [ ] Visit a hub page with inverted dates (e.g. `?start_date=2022-10&end_date=2021-08`) — should redirect with dates swapped and show the alert banner
- [ ] Verify normal date params work unchanged
- [ ] Verify async section loads (`contributor_comparison`, etc.) are unaffected by the before_action
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically detects and corrects inverted month-range inputs and notifies users with an alert when dates are swapped.
  * Removed a per-page flash notice on the admin users list to avoid redundant messages.

* **New Features**
  * Flash messages (alerts and notices) now display as prominent banners at the top of pages for clearer user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->