### PR TITLE
Fix tooltip overflow and add hover counts to wikimedia readiness page

### DIFF
--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -449,7 +449,10 @@ footer {
 
 .tooltip .tooltiptext {
     visibility: hidden;
-    white-space: nowrap;
+    width: max-content;
+    max-width: calc(100vw - 16px);
+    white-space: normal;
+    overflow-wrap: anywhere;
     background-color: #273443;
     color: #fff;
     text-align: center;

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -449,19 +449,19 @@ footer {
 
 .tooltip .tooltiptext {
     visibility: hidden;
-    width: 300px;
+    white-space: nowrap;
     background-color: #273443;
     color: #fff;
     text-align: center;
     border-radius: 6px;
-    padding: 5px;
+    padding: 5px 10px;
 
-    /* Position the tooltip text */
+    /* Position above, anchored to right edge so it never overflows the viewport */
     position: absolute;
     z-index: 1;
     bottom: 125%;
-    left: 50%;
-    margin-left: -80px;
+    right: 0;
+    left: auto;
 
     /* Fade in tooltip */
     opacity: 0;
@@ -473,8 +473,9 @@ footer {
     content: "";
     position: absolute;
     top: 100%;
-    left: 20%;
-    margin-left: -5px;
+    right: 10%;
+    left: auto;
+    margin-left: 0;
     border-width: 5px;
     border-style: solid;
     border-color: #555 transparent transparent transparent;

--- a/app/controllers/wikimedia_preparations_controller.rb
+++ b/app/controllers/wikimedia_preparations_controller.rb
@@ -38,6 +38,7 @@ class WikimediaPreparationsController < ApplicationController
 
     wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
     @wp_data = wp_presenter.hub(params[:hub_id])
+    @item_count = Hub.item_count(params[:hub_id])
   end
 
   def initiate_contributor_wp_presenter
@@ -49,5 +50,6 @@ class WikimediaPreparationsController < ApplicationController
 
     wp_presenter = WikimediaPreparationsPresenter.new(metadata_completeness)
     @wp_data = wp_presenter.contributor(params[:hub_id], params[:contributor_id])
+    @item_count = Hub.item_count(params[:hub_id], params[:contributor_id])
   end
 end


### PR DESCRIPTION
## Summary

**Tooltip overflow / excess padding** (visible on any hub or contributor page with metadata completeness percentages):
- Replaced fixed `width: 300px` with `white-space: nowrap` — tooltip now sizes to its content instead of being padded to 300px
- Changed positioning from `left: 50%; margin-left: -80px` to `right: 0; left: auto` — tooltip anchors to the right edge of the bar cell so it opens to the left, never overflowing the viewport
- Adjusted the arrow to match (`right: 10%`)

**Wikimedia Readiness / Preparations page missing hover counts**:
- `WikimediaPreparationsController` was not setting `@item_count`, so `render_percentage_with_count` received `nil` and returned a bare percentage with no tooltip
- Added `@item_count = Hub.item_count(...)` in both `initiate_hub_wp_presenter` and `initiate_contributor_wp_presenter`

## Test plan

- [ ] Hover over a metadata completeness percentage on any hub page — should show "X of Y items" without overflowing the right edge
- [ ] Visit the Wikimedia Readiness tab for a hub (e.g. Smithsonian) and hover a percentage — should now show absolute counts
- [ ] Verify the same for a contributor's Wikimedia Readiness section
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Dashboard tooltips now anchor to the right edge, use content-based sizing, and wrap text more safely to improve readability and viewport fit.
* **New Features**
  * Item counts are now populated and available in hub/contributor views, enabling visible counts where relevant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->