### PR TITLE
Fix contributor sections routing collision and tooltip viewport clipping

### DIFF
--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -449,22 +449,22 @@ footer {
 
 .tooltip .tooltiptext {
     visibility: hidden;
-    width: max-content;
-    max-width: calc(100vw - 16px);
+    width: 300px;
+    max-width: calc(100vw - 2rem);
     white-space: normal;
-    overflow-wrap: anywhere;
+    overflow-wrap: break-word;
     background-color: #273443;
     color: #fff;
     text-align: center;
     border-radius: 6px;
     padding: 5px 10px;
 
-    /* Position above, anchored to right edge so it never overflows the viewport */
+    /* Center above the trigger */
     position: absolute;
     z-index: 1;
     bottom: 125%;
-    right: 0;
-    left: auto;
+    left: 50%;
+    transform: translateX(-50%);
 
     /* Fade in tooltip */
     opacity: 0;
@@ -476,9 +476,8 @@ footer {
     content: "";
     position: absolute;
     top: 100%;
-    right: 10%;
-    left: auto;
-    margin-left: 0;
+    left: 50%;
+    margin-left: -5px;
     border-width: 5px;
     border-style: solid;
     border-color: #555 transparent transparent transparent;

--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -480,7 +480,7 @@ footer {
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;
-    border-color: #555 transparent transparent transparent;
+    border-color: #273443 transparent transparent transparent;
 }
 
 /* Show the tooltip text when you mouse over or focus the tooltip container */

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     post "wikimedia_cache/rebuild", to: "wikimedia_cache#rebuild"
   end
 
-  resources :hubs, id: /.*/, only: [:index, :show] do
+  resources :hubs, id: /[^\/]+/, only: [:index, :show] do
     get :sections
     get :website_overview
     get :api_overview
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
     get :metadata_completeness
     get :wikimedia_overview
 
-    resources :contributors, id: /.*/, only: [:index, :show] do
+    resources :contributors, id: /[^\/]+/, only: [:index, :show] do
       get :sections
       get :contributor_website_overview
       get :contributor_api_overview


### PR DESCRIPTION
## Summary

- **Routing fix**: `id: /.*/` on `resources :hubs` allowed `:id` to match slashes, causing URLs like `/hubs/X/contributors/Y/sections` to be routed to `hubs#sections` (with `params[:hub_id]` nil) instead of `contributors#sections`. All contributor data sources returned 0/nil, showing "Data not available" on every contributor page. Fixed by changing both hub and contributor route constraints to `id: /[^\/]+/` — names contain spaces but never slashes.
- **Tooltip fix**: `right: 0 + width: max-content` from PR #269 extended the tooltip leftward for left-column triggers, clipping at the viewport edge. Replaced with centered positioning (`left: 50% + translateX(-50%)`) and a fixed 300px width so text wraps instead of clipping.

## Test plan

- [ ] Visit a contributor page (e.g. `/hubs/Heartland%20Hub/contributors/Missouri%20Historical%20Society`) — all four data sections should load with real data instead of "Data not available"
- [ ] Verify hub pages still load normally
- [ ] Hover tooltips on left-column headings (DPLA Website) — text should wrap, not clip off the left edge
- [ ] Hover tooltips on right-column headings (Metadata Completeness) — should still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved tooltip appearance: fixed width, better text wrapping, centered placement above triggers, and refined arrow styling for clearer, more consistent tooltips.

* **Bug Fixes**
  * Stricter URL path validation for hub and contributor pages to block invalid multi-segment IDs and reduce incorrect requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->