### PR TITLE
Fix UrlGenerationError for hub/contributor names containing slashes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,14 @@ class ApplicationController < ActionController::Base
   end
   helper_method :admin_for_all_hubs?
 
+  # Encode literal slashes in hub/contributor names as %2F so they survive
+  # Rails' id: /[^\/]+/ route constraint during URL generation. The constraint
+  # prevents routing collisions but rejects raw "/" in path helper arguments.
+  def route_id(name)
+    name.to_s.gsub("/", "%2F")
+  end
+  helper_method :route_id
+
   def require_admin!
     unless current_user.admin
       flash[:alert] = "You don't have permission to do that."

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -13,7 +13,7 @@ class ContributorsController < ApplicationController
     return render_not_found unless Hub.exists?(params[:hub_id])
 
     unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
-      return redirect_to hub_contributors_path(current_user.hub)
+      return redirect_to hub_contributors_path(route_id(current_user.hub))
     end
 
     assign_start_and_end_dates
@@ -41,7 +41,7 @@ class ContributorsController < ApplicationController
     @target     = @contributor
 
     unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
-      redirect_to hub_path(current_user.hub)
+      redirect_to hub_path(route_id(current_user.hub))
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,7 +19,7 @@ class EventsController < ApplicationController
     @target = params[:contributor_id] ? @contributor : @hub
 
     unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
-      redirect_to hub_path(current_user.hub)
+      redirect_to hub_path(route_id(current_user.hub))
     end
   end
 

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -10,7 +10,7 @@ class HubsController < ApplicationController
   include TooltipsHelper
 
   def index
-    return redirect_to(hub_path(current_user.hub)) unless admin_for_all_hubs?
+    return redirect_to(hub_path(route_id(current_user.hub))) unless admin_for_all_hubs?
 
     assign_start_and_end_dates
     @hubs = Hub.all_with_counts
@@ -18,7 +18,7 @@ class HubsController < ApplicationController
 
   def show
     return render_not_found unless Hub.exists?(params[:id])
-    return redirect_to(hub_path(current_user.hub)) unless current_user.hub == params[:id] || admin_for_all_hubs?
+    return redirect_to(hub_path(route_id(current_user.hub))) unless current_user.hub == params[:id] || admin_for_all_hubs?
 
     assign_start_and_end_dates
     @hub = Hub.new(params[:id], @start_date, @end_date)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -19,7 +19,7 @@ class LocationsController < ApplicationController
     @target = params[:contributor_id] ? @contributor : @hub
 
     unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
-      redirect_to hub_path(current_user.hub)
+      redirect_to hub_path(route_id(current_user.hub))
     end
   end
 end

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -21,7 +21,7 @@ class TimelinesController < ApplicationController
     @id = params[:id]
 
     unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
-      redirect_to hub_path(current_user.hub)
+      redirect_to hub_path(route_id(current_user.hub))
     end
   end
 end

--- a/app/controllers/wikimedia_preparations_controller.rb
+++ b/app/controllers/wikimedia_preparations_controller.rb
@@ -24,7 +24,7 @@ class WikimediaPreparationsController < ApplicationController
     @id = params[:id]
 
     unless current_user.hub == params[:hub_id] || admin_for_all_hubs?
-      redirect_to hub_path(current_user.hub)
+      redirect_to hub_path(route_id(current_user.hub))
     end
   end
 

--- a/app/helpers/data_menu_helper.rb
+++ b/app/helpers/data_menu_helper.rb
@@ -1,73 +1,73 @@
 module DataMenuHelper
-  
+
   def render_overview_link(target)
     path = target.is_a?(Hub) ?
-      hub_path(target.name, date_opts) : 
-      hub_contributor_path(target.hub.name, target.name, date_opts)
+      hub_path(route_id(target.name), date_opts) :
+      hub_contributor_path(route_id(target.hub.name), route_id(target.name), date_opts)
 
     link_to("Overview", path, html_opts(path))
   end
 
   def render_website_timelines_link(target)
     path = target.is_a?(Hub) ?
-      hub_timeline_path(target.name, 'website', date_opts) :
-      hub_contributor_timeline_path(target.hub.name, target.name, 'website', date_opts)
+      hub_timeline_path(route_id(target.name), 'website', date_opts) :
+      hub_contributor_timeline_path(route_id(target.hub.name), route_id(target.name), 'website', date_opts)
 
     link_to("DPLA website use timelines", path, html_opts(path))
   end
 
   def render_api_timelines_link(target)
     path = target.is_a?(Hub) ?
-      hub_timeline_path(target.name, 'api', date_opts) :
-      hub_contributor_timeline_path(target.hub.name, target.name, 'api', date_opts)
+      hub_timeline_path(route_id(target.name), 'api', date_opts) :
+      hub_contributor_timeline_path(route_id(target.hub.name), route_id(target.name), 'api', date_opts)
 
     link_to("API use timelines", path, html_opts(path))
   end
 
   def render_locations_link(target)
     path = target.is_a?(Hub) ?
-      hub_locations_path(target.name, date_opts) :
-      hub_contributor_locations_path(target.hub.name, target.name, date_opts)
+      hub_locations_path(route_id(target.name), date_opts) :
+      hub_contributor_locations_path(route_id(target.hub.name), route_id(target.name), date_opts)
 
     link_to("DPLA website user locations", path, html_opts(path))
   end
 
   def render_view_item_link(target)
     path = target.is_a?(Hub) ?
-      hub_event_path(target.name, 'view_item', date_opts) :
-      hub_contributor_event_path(target.hub.name, target.name, 'view_item', date_opts)
+      hub_event_path(route_id(target.name), 'view_item', date_opts) :
+      hub_contributor_event_path(route_id(target.hub.name), route_id(target.name), 'view_item', date_opts)
 
     link_to("Digital library catalog views", path, html_opts(path))
   end
 
   def render_view_exhibit_link(target)
     path = target.is_a?(Hub) ?
-      hub_event_path(target.name, 'view_exhibit', date_opts) : 
-      hub_contributor_event_path(target.hub.name, target.name, 'view_exhibit', date_opts)
+      hub_event_path(route_id(target.name), 'view_exhibit', date_opts) :
+      hub_contributor_event_path(route_id(target.hub.name), route_id(target.name), 'view_exhibit', date_opts)
 
     link_to("Exhibition views", path, html_opts(path))
   end
 
   def render_view_pss_link(target)
     path = target.is_a?(Hub) ?
-      hub_event_path(target.name, 'view_pss', date_opts) : 
-      hub_contributor_event_path(target.hub.name, target.name, 'view_pss', date_opts)
+      hub_event_path(route_id(target.name), 'view_pss', date_opts) :
+      hub_contributor_event_path(route_id(target.hub.name), route_id(target.name), 'view_pss', date_opts)
 
     link_to("Primary source set views", path, html_opts(path))
   end
 
   def render_click_through_link(target)
     path = target.is_a?(Hub) ?
-      hub_event_path(target.name, 'click_through', date_opts) :
-      hub_contributor_event_path(target.hub.name, target.name, 'click_through', date_opts)
+      hub_event_path(route_id(target.name), 'click_through', date_opts) :
+      hub_contributor_event_path(route_id(target.hub.name), route_id(target.name), 'click_through', date_opts)
 
     link_to("DPLA website click throughs", path, html_opts(path))
   end
 
   def render_view_api_link(target)
     path = target.is_a?(Hub) ?
-      hub_event_path(target.name, 'view_api', date_opts) : 
-      hub_contributor_event_path(target.hub.name, target.name, 'view_api', date_opts)
+      hub_event_path(route_id(target.name), 'view_api', date_opts) :
+      hub_contributor_event_path(route_id(target.hub.name), route_id(target.name), 'view_api', date_opts)
 
     link_to("API item views", path, html_opts(path))
   end
@@ -84,8 +84,8 @@ module DataMenuHelper
 
   def render_wikimedia_readiness_link(target)
     path = target.is_a?(Hub) ?
-      hub_wikimedia_preparations_path(target.name, date_opts) :
-      hub_contributor_wikimedia_preparations_path(target.hub.name, target.name, date_opts)
+      hub_wikimedia_preparations_path(route_id(target.name), date_opts) :
+      hub_contributor_wikimedia_preparations_path(route_id(target.hub.name), route_id(target.name), date_opts)
 
     link_to("Wikimedia readiness", path, html_opts(path))
   end

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -71,7 +71,7 @@
       <tbody>
         <% @contributors_item_count.each do |c| %>
           <tr>
-            <td><%= link_to c["term"], hub_contributor_path(params[:hub_id], c["term"], date_opts) %></td>
+            <td><%= link_to c["term"], hub_contributor_path(route_id(params[:hub_id]), route_id(c["term"]), date_opts) %></td>
             <%# colspan spans all data columns; exact count varies by hub (BWS, Wikimedia, API, etc.) %>
             <td colspan="99">—</td>
           </tr>

--- a/app/views/contributors/show.html.erb
+++ b/app/views/contributors/show.html.erb
@@ -20,7 +20,7 @@
   <div class="data-content">
 
     <%= render_async_section hub_contributor_sections_path(
-          @contributor.hub.name, @contributor.name, date_opts) do %>
+          route_id(@contributor.hub.name), route_id(@contributor.name), date_opts) do %>
       <%= render partial: "shared/contributor_sections" %>
     <% end %>
 

--- a/app/views/hubs/index.html.erb
+++ b/app/views/hubs/index.html.erb
@@ -7,7 +7,7 @@
     <ul class="hub-grid">
       <% @hubs.each do |hub| %>
         <li class="hub-card">
-          <%= link_to hub_path(hub['term']), class: "hub-card-link" do %>
+          <%= link_to hub_path(route_id(hub['term'])), class: "hub-card-link" do %>
             <span class="hub-card-name"><%= hub['term'] %></span>
             <span class="hub-card-count"><%= number_with_delimiter(hub['count']) %> items</span>
           <% end %>

--- a/app/views/hubs/show.html.erb
+++ b/app/views/hubs/show.html.erb
@@ -18,7 +18,7 @@
 
   <div class="data-content">
 
-    <%= render_async_section hub_sections_path(@hub.name, date_opts) do %>
+    <%= render_async_section hub_sections_path(route_id(@hub.name), date_opts) do %>
       <%= render partial: "shared/hub_sections" %>
     <% end %>
 

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -6,13 +6,13 @@
         </li>
     <% else %>
         <li>
-          <%= link_to "Overview", hub_path(current_user.hub, date_opts) %>
+          <%= link_to "Overview", hub_path(route_id(current_user.hub), date_opts) %>
         </li>
         <% @hub ||= Hub.new(current_user.hub, "", "") %>
         <% if @hub.contributors.count > 1 %>
           <li>
             <%= link_to "Contributors",
-                hub_contributors_path(current_user.hub, date_opts) %>
+                hub_contributors_path(route_id(current_user.hub), date_opts) %>
           </li>
         <% end %>
     <% end %>

--- a/app/views/shared/_sub_navigation.html.erb
+++ b/app/views/shared/_sub_navigation.html.erb
@@ -5,12 +5,12 @@
     <nav>
       <ul>
         <li>
-          <%= link_to hub.name, hub_path(hub.name) %>
+          <%= link_to hub.name, hub_path(route_id(hub.name)) %>
         </li>
         <% if hub.contributors.count > 1 %>
           <li>
             <%= link_to "Contributors",
-                hub_contributors_path(hub.name, date_opts) %>
+                hub_contributors_path(route_id(hub.name), date_opts) %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
## Summary

- Adds `route_id` helper to `ApplicationController` that encodes literal `/` as `%2F` in hub/contributor names before they are passed to Rails path helpers
- Applies `route_id` to every hub/contributor name in all controllers and views that generate hub/contributor paths

## Root cause

PR #270 changed the route constraint from `id: /.*/` to `id: /[^\/]+/` to fix a routing collision (where hub sections URLs were matching as contributor URLs). That constraint fix was correct, but it also causes `ActionController::UrlGenerationError` during URL *generation* when a hub or contributor name contains a literal `/` — e.g. "NJ/DE Digital Collective". Rails checks the raw string value against the constraint before encoding it, so the literal slash fails `[^\/]+` and raises an error.

Sentry issue: DPLA-FRONTEND-1JB — 500 on the hubs index page for admin users.

## How the fix works

`route_id("NJ/DE Digital Collective")` → `"NJ%2FDE Digital Collective"`. This value passes `[^\/]+` (no literal `/`), and Rails writes it into the URL as-is (it does not double-encode the `%`). On the incoming request side, `%2F` in the URL is treated as part of the path segment (not a separator), so routing matches correctly and Rails decodes it back to `NJ/DE Digital Collective` in `params`.

## Test plan

- [ ] Visit the hubs index page (`/hubs`) as an admin — confirm "NJ/DE Digital Collective" hub card links render without 500
- [ ] Visit a hub with a slash in the name — confirm the hub show page loads
- [ ] Visit a contributor under a hub with a slash in the name — confirm contributor pages load
- [ ] Visit a hub/contributor name **without** slashes — confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL encoding for hub and contributor identifiers containing special characters (forward slashes) to ensure proper routing and navigation throughout the application. This improves stability when working with items that have slashes in their names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->