### PR TITLE
Fix contributor sections date scoping, slash encoding in comparison table, and header wrapping

### DIFF
--- a/app/assets/stylesheets/dashboard.css
+++ b/app/assets/stylesheets/dashboard.css
@@ -397,6 +397,8 @@ table#comparison td:first-child {
 
 table#comparison th {
   cursor: pointer;
+  white-space: normal;
+  min-width: 4em;
 }
 
 table#comparison th.headerSortUp::after {

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -68,6 +68,8 @@ class ContributorsController < ApplicationController
     contrib_id = params[:contributor_id]
     all_start  = min_date
     all_end    = max_date
+    sec_start  = params[:start_date].present? ? @start_date : all_start
+    sec_end    = params[:start_date].present? ? @end_date   : all_end
     end_date   = @end_date
 
     @item_count = Hub.item_count(hub_id, contrib_id)
@@ -80,7 +82,7 @@ class ContributorsController < ApplicationController
     end
     website_overview_t = Thread.new do
       overview = WebsiteOverview.build { |b|
-        b.hub = hub_id; b.contributor = contrib_id; b.start_date = @start_date; b.end_date = @end_date
+        b.hub = hub_id; b.contributor = contrib_id; b.start_date = sec_start; b.end_date = sec_end
       }
       overview.response
       overview
@@ -89,7 +91,7 @@ class ContributorsController < ApplicationController
     end
     website_events_t = Thread.new do
       WebsiteEventTotals.build { |b|
-        b.hub = hub_id; b.contributor = contrib_id; b.start_date = @start_date; b.end_date = @end_date
+        b.hub = hub_id; b.contributor = contrib_id; b.start_date = sec_start; b.end_date = sec_end
       }
     rescue => e
       Rails.logger.error(e); nil
@@ -101,8 +103,8 @@ class ContributorsController < ApplicationController
       {
         wp: WikimediaPreparationsPresenter.new(mc).contributor(hub_id, contrib_id),
         wa: WikimediaAnalyticsPresenter.new(
-              start_month: all_start.strftime("%Y-%m"),
-              end_month:   all_end.strftime("%Y-%m")
+              start_month: sec_start.strftime("%Y-%m"),
+              end_month:   sec_end.strftime("%Y-%m")
             ).contributor(hub_id, contrib_id),
         mc: MetadataCompletenessPresenter.new(mc).contributor(hub_id, contrib_id)
       }
@@ -123,7 +125,7 @@ class ContributorsController < ApplicationController
     @wa_data              = mc_data[:wa]
     @mc_data              = mc_data[:mc]
     @wikimedia_participant = WikimediaParticipant.participant?(hub_id, contrib_id)
-    @target               = Contributor.new(contrib_id, hub_id, all_start, all_end)
+    @target               = Contributor.new(contrib_id, hub_id, sec_start, sec_end)
 
     render partial: "shared/contributor_sections"
   end

--- a/app/views/shared/_contributor_comparison.html.erb
+++ b/app/views/shared/_contributor_comparison.html.erb
@@ -128,13 +128,13 @@
 <div class='download'>
   <%= link_to 'Download CSV', { controller: :contributors,
                                 action: params[:action],
-                                hub_id: params[:hub_id],
+                                hub_id: route_id(params[:hub_id]),
                                 format: :csv }.merge(date_opts) %>
 </div>
 
 <div class="comparison-table-wrapper">
 <table id='comparison'
-       data-ga-url="<%= contributor_ga_data_path({ hub_id: params[:hub_id] }.merge(date_opts)) %>">
+       data-ga-url="<%= contributor_ga_data_path({ hub_id: route_id(params[:hub_id]) }.merge(date_opts)) %>">
   <thead>
     <tr>
       <th>Contributor</th>
@@ -172,7 +172,7 @@
       <tr>
         <td>
           <%= link_to contributor, { controller: :contributors, action: :show,
-                                     hub_id: params[:hub_id], id: contributor }.merge(date_opts) %>
+                                     hub_id: route_id(params[:hub_id]), id: route_id(contributor) }.merge(date_opts) %>
         </td>
         <td class="website-view ga-loading"
             data-ga-contributor="<%= contributor %>"


### PR DESCRIPTION
## Summary

- **Date scoping regression**: `ContributorsController#sections` was using `@start_date`/`@end_date` for `website_overview_t` and `website_events_t`, causing the default (no params) view to show current month instead of all-time data. Add `sec_start`/`sec_end` logic mirroring `HubsController#sections`: default to all-time when no date params are present, otherwise use the selected range. Also fixes `@target` and the Wikimedia analytics presenter to use `sec_start`/`sec_end`.
- **Slash encoding (Sentry DPLA-FRONTEND-1JE)**: The contributor comparison table's `link_to` was passing raw contributor/hub names as `:id`/`:hub_id` without `route_id()` encoding. Contributor names containing `/` (e.g. "Latino/a") caused `ActionView::Template::Error` and broke the entire table render.
- **Comparison table header wrapping**: Add `white-space: normal` and `min-width: 4em` to `table#comparison th` so long header labels (e.g. "dp.la Click Throughs") wrap instead of forcing horizontal scroll.

## Test plan

- [ ] Load a contributor page with no date params — confirm "View counts are displayed for all time" message appears and data covers the full date range
- [ ] Select a specific month — confirm data updates to that range
- [ ] Load a hub comparison page for Mountain West Digital Library — confirm the table renders without error and the "Latino Roots Project..." contributor row is visible with a working link
- [ ] Confirm comparison table headers wrap on narrower viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved comparison table header layout with text wrapping and minimum width enforcement.

* **Refactor**
  * Enhanced date range filtering to respect custom date parameters when provided.
  * Updated routing consistency for analytics tracking and contributor links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->