### PR TITLE
Guard against blank contributor_id in sections action

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -62,16 +62,16 @@ class ContributorsController < ApplicationController
   # concurrently, returning one combined HTML response instead of four.
   #
   def sections
-    assign_start_and_end_dates
-
-    hub_id     = params[:hub_id]
     contrib_id = params[:contributor_id]
     return head :not_found if contrib_id.blank?
 
-    all_start  = min_date
-    all_end    = max_date
-    sec_start  = params[:start_date].present? ? @start_date : all_start
-    sec_end    = params[:start_date].present? ? @end_date   : all_end
+    assign_start_and_end_dates
+
+    hub_id    = params[:hub_id]
+    all_start = min_date
+    all_end   = max_date
+    sec_start = params[:start_date].present? ? @start_date : all_start
+    sec_end   = params[:start_date].present? ? @end_date   : all_end
     end_date   = @end_date
 
     @item_count = Hub.item_count(hub_id, contrib_id)

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -66,6 +66,8 @@ class ContributorsController < ApplicationController
 
     hub_id     = params[:hub_id]
     contrib_id = params[:contributor_id]
+    return head :not_found if contrib_id.blank?
+
     all_start  = min_date
     all_end    = max_date
     sec_start  = params[:start_date].present? ? @start_date : all_start


### PR DESCRIPTION
## Summary

- Adds `return head :not_found if contrib_id.blank?` at the top of `ContributorsController#sections`
- The `id: /.*/` route constraint allows empty URL segments, so a malformed URL like `/hubs/foo/contributors//sections` can reach this action with `contributor_id` as `""` or `nil`
- Without this guard, the blank id propagates to `@target.name`, which causes `ActionView::Template::Error` in `_wikimedia_overview.html.erb` when `render_wikimedia_readiness_link` passes a blank string to the path helper (Sentry 1JC: `contributor_id: nil`, 1JD: `contributor_id: ""`)

## Test plan

- [ ] Load a valid contributor page (e.g. `/hubs/Heartland%20Hub/contributors/SomeName`) — sections should render normally
- [ ] Hit `/hubs/Heartland%20Hub/contributors//sections` directly — should return 404 instead of raising ActionView::Template::Error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contributor section endpoint now returns 404 when the contributor identifier is missing, avoiding unnecessary server work and preventing downstream errors; improves error handling and response behavior for malformed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->