### PR TITLE
Force GA fetches inside worker threads; extract section_date_range

### DIFF
--- a/app/controllers/concerns/date_setter.rb
+++ b/app/controllers/concerns/date_setter.rb
@@ -27,6 +27,21 @@ module DateSetter
   end
 
   ##
+  # Returns the effective [start, end] date range for a page section.
+  # When date params are present use the requested range; otherwise fall back to all-time.
+  # Requires assign_start_and_end_dates to have already been called.
+  #
+  # @return [Array<Date>] [sec_start, sec_end]
+  #
+  def section_date_range
+    if params[:start_date].present?
+      [@start_date, @end_date]
+    else
+      [min_date, max_date]
+    end
+  end
+
+  ##
   # This assigns values to @start_date and @end_date using params[:start_date]
   # and params[:end_date], both of which are expected to be in the format
   # "YYYY-MM"

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -67,12 +67,10 @@ class ContributorsController < ApplicationController
 
     assign_start_and_end_dates
 
-    hub_id    = params[:hub_id]
-    all_start = min_date
-    all_end   = max_date
-    sec_start = params[:start_date].present? ? @start_date : all_start
-    sec_end   = params[:start_date].present? ? @end_date   : all_end
-    end_date   = @end_date
+    hub_id             = params[:hub_id]
+    all_start, all_end = min_date, max_date
+    sec_start, sec_end = section_date_range
+    end_date           = @end_date
 
     @item_count = Hub.item_count(hub_id, contrib_id)
     wiki_views_t = Thread.new do
@@ -92,9 +90,11 @@ class ContributorsController < ApplicationController
       Rails.logger.error(e); nil
     end
     website_events_t = Thread.new do
-      WebsiteEventTotals.build { |b|
+      totals = WebsiteEventTotals.build { |b|
         b.hub = hub_id; b.contributor = contrib_id; b.start_date = sec_start; b.end_date = sec_end
       }
+      totals.response
+      totals
     rescue => e
       Rails.logger.error(e); nil
     end

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -41,12 +41,10 @@ class HubsController < ApplicationController
   def sections
     assign_start_and_end_dates
 
-    hub_id    = params[:hub_id]
-    all_start = min_date
-    all_end   = max_date
-    sec_start = params[:start_date].present? ? @start_date : all_start
-    sec_end   = params[:start_date].present? ? @end_date   : all_end
-    end_date  = @end_date
+    hub_id              = params[:hub_id]
+    all_start, all_end  = min_date, max_date
+    sec_start, sec_end  = section_date_range
+    end_date            = @end_date
 
     first_month = Rails.cache.fetch("wikimedia_start_month:#{hub_id}", expires_in: 24.hours) do
       WikimediaCache.where(hub: hub_id, contributor: "").minimum(:month)
@@ -70,16 +68,20 @@ class HubsController < ApplicationController
       Rails.logger.error(e); nil
     end
     website_overview_t = Thread.new do
-      WebsiteOverview.build { |b|
+      overview = WebsiteOverview.build { |b|
         b.hub = hub_id; b.start_date = sec_start; b.end_date = sec_end
       }
+      overview.response
+      overview
     rescue => e
       Rails.logger.error(e); nil
     end
     website_events_t = Thread.new do
-      WebsiteEventTotals.build { |b|
+      totals = WebsiteEventTotals.build { |b|
         b.hub = hub_id; b.start_date = sec_start; b.end_date = sec_end
       }
+      totals.response
+      totals
     rescue => e
       Rails.logger.error(e); nil
     end


### PR DESCRIPTION
## Summary

Two independent improvements surfaced during a code review pass:

**1. Lazy builder threads (performance)**

`website_overview_t` and `website_events_t` in both `HubsController#sections` and `ContributorsController#sections` were returning lazy builder objects without calling `.response`. The GA4 HTTP fetch therefore happened on the main request thread *after* all worker threads had already joined, defeating the concurrency entirely.

Fix: call `.response` inside each thread before returning the object. The builder memoizes the result (`@response ||= ...`), so subsequent accessors (`.events`, `.sessions`, etc.) called after `.value` on the main thread are instant cache hits.

**2. DateSetter#section_date_range (duplication)**

The three-line pattern `sec_start = params[:start_date].present? ? @start_date : min_date` was verbatim-identical in both sections actions. Extracted to `DateSetter#section_date_range` and replaced both occurrences with `sec_start, sec_end = section_date_range`.

## Test plan

- [ ] Load a hub page with no date params — confirm sections render with all-time data
- [ ] Load a hub page with `?start_date=2024-01&end_date=2024-06` — confirm sections render with the selected date range
- [ ] Same two checks for a contributor page
- [ ] Confirm pages load at least as fast as before (GA fetches should now be concurrent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made date-range behavior more consistent across section views, reducing edge-case mismatches when start/end dates are or aren’t provided.
  * Streamlined internal handling of section and overall ranges for clearer, predictable results.
  * Ensured background data generation materializes responses more reliably for timely, consistent report output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->