### PR TITLE
Guard hub async endpoints against blank/non-existent hub_id

### DIFF
--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -259,6 +259,9 @@ class HubsController < ApplicationController
   private
 
   def authorize_hub_scope!
-    render_not_found unless Hub.exists?(params[:hub_id])
+    return render_not_found unless Hub.exists?(params[:hub_id])
+    return if current_user.hub == params[:hub_id] || admin_for_all_hubs?
+
+    head :forbidden
   end
 end

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -9,6 +9,11 @@ class HubsController < ApplicationController
   include MetadataCompletenessHelper
   include TooltipsHelper
 
+  before_action :authorize_hub_scope!, only: %i[
+    sections website_overview api_overview bws_overview
+    item_count totals metadata_completeness wikimedia_overview
+  ]
+
   def index
     return redirect_to(hub_path(route_id(current_user.hub))) unless admin_for_all_hubs?
 
@@ -249,5 +254,11 @@ class HubsController < ApplicationController
     @target                = Hub.new(params[:hub_id], @start_date, @end_date)
 
     render partial: "shared/wikimedia_overview"
+  end
+
+  private
+
+  def authorize_hub_scope!
+    render_not_found unless Hub.exists?(params[:hub_id])
   end
 end


### PR DESCRIPTION
## Summary

- `ContributorsController` already has `authorize_contributor_scope!` covering all async XHR endpoints (added in a prior PR)
- `HubsController` had no equivalent — a malformed request with a blank or non-existent `hub_id` could reach downstream builder code and produce confusing errors instead of a clean 404
- Adds `authorize_hub_scope!` as a `before_action` on all eight hub async endpoints: `sections`, `website_overview`, `api_overview`, `bws_overview`, `item_count`, `totals`, `metadata_completeness`, `wikimedia_overview`
- Uses the same `Hub.exists?` + `render_not_found` pattern already established elsewhere in the codebase

## Test plan

- [ ] Load a hub page normally — all sections should render as before
- [ ] Hit `/hubs/Heartland%20Hub/sections` directly — should return normally for a valid hub
- [ ] Hit `/hubs/not-a-real-hub/sections` — should return 404
- [ ] Confirm the same for at least one other protected action (e.g. `website_overview`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests for hub-specific views now return "not found" when the requested hub does not exist, avoiding unexpected errors.
  * Access to hub-restricted pages is blocked for users who are neither members of the hub nor global admins (returns "forbidden"), preventing unauthorized data access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->