### PR TITLE
Fix three date-range bugs on hub and contributor pages

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -73,6 +73,13 @@ class ContributorsController < ApplicationController
     end_date           = @end_date
 
     @item_count = Hub.item_count(hub_id, contrib_id)
+    website_views_t = Thread.new do
+      WebsiteOverview.build { |b|
+        b.hub = hub_id; b.contributor = contrib_id; b.start_date = all_start; b.end_date = all_end
+      }.events
+    rescue => e
+      Rails.logger.error(e); nil
+    end
     wiki_views_t = Thread.new do
       WikimediaAnalyticsPresenter.new(
         start_month: all_start.strftime("%Y-%m"), end_month: all_end.strftime("%Y-%m")
@@ -114,12 +121,12 @@ class ContributorsController < ApplicationController
       Rails.logger.error(e); {}
     end
 
-    [wiki_views_t,
+    [website_views_t, wiki_views_t,
      website_overview_t, website_events_t, mc_thread].each(&:join)
 
     mc_data = mc_thread.value || {}
 
-    @website_views        = website_overview_t.value&.events
+    @website_views        = website_views_t.value
     @wikimedia_views      = wiki_views_t.value
     @website_overview     = website_overview_t.value
     @website_event_totals = website_events_t.value

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,8 +37,11 @@ module ApplicationHelper
     # Pass through whatever params are in the current request so date range
     # selections (including the current month) are preserved across navigation.
     # Return {} when no params are set so all-time links stay clean.
-    return {} unless params[:start_date].present?
+    return {} unless date_range_active?
 
-    { start_date: current_start_date, end_date: current_end_date }
+    opts = {}
+    opts[:start_date] = current_start_date if params[:start_date].present?
+    opts[:end_date]   = current_end_date   if params[:end_date].present?
+    opts
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,8 +15,10 @@ module ApplicationHelper
     render_async(path, { error_message: default_error }.merge(options), &block)
   end
 
+  # Returns nil when no start_date param is present so the date dropdown
+  # shows the first available option (earliest month) rather than the current month.
   def current_start_date
-    @start_date.strftime("%Y-%m") rescue nil
+    params[:start_date].present? ? (@start_date.strftime("%Y-%m") rescue nil) : nil
   end
 
   def current_end_date
@@ -32,10 +34,10 @@ module ApplicationHelper
   end
 
   def date_opts
-    # The default view (no params) always shows the current month. Omit params
-    # from links when the selected range matches the default so URLs stay clean.
-    current_month = Date.current.strftime("%Y-%m")
-    return {} if current_start_date == current_month && current_end_date == current_month
+    # Pass through whatever params are in the current request so date range
+    # selections (including the current month) are preserved across navigation.
+    # Return {} when no params are set so all-time links stay clean.
+    return {} unless params[:start_date].present?
 
     { start_date: current_start_date, end_date: current_end_date }
   end


### PR DESCRIPTION
## Summary

- **Contributor Totals "Views on dp.la" was date-filtered**: Added a separate `website_views_t` thread using `all_start`/`all_end` (all-time) in `ContributorsController#sections`, mirroring the hub page. Previously `@website_views` came from `website_overview_t` which uses the user-selected date range.
- **Start dropdown showed current month instead of earliest**: `current_start_date` now returns `nil` when no `start_date` param is present, so `options_for_select` leaves the first option (earliest available month) as the browser default.
- **Selecting the current month showed all-time data**: `date_opts` was stripping params when the selection matched the current month, causing the sections AJAX request to arrive with no params and fall back to all-time. Now passes through validated `@start_date`/`@end_date` whenever params are present.

## Test plan

- [ ] Hub page with no URL params: all sections show all-time data; Start dropdown shows earliest month; Totals block shows all-time "Views on dp.la"
- [ ] Hub page with `?start_date=2026-04&end_date=2026-04`: sections show current-month data (not all-time); "not affected by date range" note appears in Totals; Start/End dropdowns show April 2026
- [ ] Hub page with a past date range (e.g. `?start_date=2025-01&end_date=2025-06`): sections show that range; Totals "Views on dp.la" stays all-time
- [ ] Contributor page: same three checks as above; "Views on dp.la" in Totals stays all-time regardless of date params
- [ ] "View all-time data" link removes params and returns to all-time view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date filter behavior so empty date params are ignored and user-selected date ranges persist across navigation.

* **Refactor**
  * Improved loading of website overview metrics by running additional work in parallel and handling errors more gracefully, reducing page load stalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->