### PR TITLE
Fix five AI code quality findings in metadata_completeness.rb and contributors view

### DIFF
--- a/app/lib/metadata_completeness.rb
+++ b/app/lib/metadata_completeness.rb
@@ -67,7 +67,7 @@ class MetadataCompleteness
     date = @end_date
     response = nil
 
-    while response == nil
+    while response.nil?
       break if date < min_date
 
       # File path in format YYYY/MM/filename.csv
@@ -78,7 +78,7 @@ class MetadataCompleteness
         csv_files = SThreeResponseBuilder.list(prefix).contents
           .select{ |c| c.key.ends_with?(".csv") }
         key = csv_files.first.key unless csv_files.empty?
-      rescue Exception => e
+      rescue StandardError => e
         Rails.logger.debug(e)
         break
       end
@@ -89,18 +89,18 @@ class MetadataCompleteness
         rescue Aws::S3::Errors::NoSuchKey
           Rails.logger.debug("#{key} does not exist.")
           # Loop continues
-        rescue Exception => e
+        rescue StandardError => e
           Rails.logger.debug(e)
           break
         end
       end
 
-      date = date.last_month
+      date = date.last_month unless response
     end
 
     # set @file_date to the date for which a file was found in AWS
-    @file_date = date
-    return response
+    @file_date = response ? date : nil
+    response
   end
 
   ##

--- a/app/lib/metadata_completeness.rb
+++ b/app/lib/metadata_completeness.rb
@@ -61,7 +61,7 @@ class MetadataCompleteness
   # If no data is available for that month, get the previous month.
   # Continue trying until data is available or min date is surpassed.
   #
-  # @return Aws::S3::Types::GetObjectOutput
+  # @return [Aws::S3::Types::GetObjectOutput, nil]
   #
   def sThree_response(file_name)
     date = @end_date

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -55,7 +55,7 @@
 
 <main>
 
-  <div class="clear"/>
+  <div class="clear"></div>
 
   <h2>Contributors</h2>
 


### PR DESCRIPTION
## Summary

- **`metadata_completeness.rb` — 4 fixes:**
  - `while response == nil` → `while response.nil?` (idiomatic Ruby)
  - Two `rescue Exception => e` → `rescue StandardError => e` to avoid swallowing system-level signals (`SignalException`, `NoMemoryError`, etc.)
  - **Bug fix:** `date = date.last_month` → `date = date.last_month unless response` — previously the date was unconditionally advanced at the end of each loop iteration, even when a file was successfully found. This caused `@file_date` to be one month behind the actual file date. (`WikimediaAnalytics` already had the correct guard.)
  - **Bug fix:** `@file_date = date` → `@file_date = response ? date : nil` — previously `@file_date` was set to a date even when no S3 file was found (response is nil). Callers now correctly receive `nil` when no data is available. (`WikimediaAnalytics` already had this correct.)

- **`contributors/index.html.erb` — 1 fix:**
  - `<div class="clear"/>` → `<div class="clear"></div>` — self-closing div tags are invalid HTML5.

All five findings were surfaced by GitHub's AI code quality scanner after the PR #280 merge.

## Test plan

- [ ] Confirm `@file_date` returns the correct month when a metadata completeness CSV is found in S3
- [ ] Confirm `@file_date` returns `nil` when no CSV is found in S3 (rather than a stale fallback date)
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTML structure on the Contributors page for consistent display and better cross-browser compatibility.

* **Refactor**
  * Improved metadata retrieval robustness with safer exception handling, more reliable retry/backtracking logic, and conditional date assignment when no data is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->