### PR TITLE
Fix URI errors, hub slash routing, and JS re-execution for NJ/DE Digital Collective

### DIFF
--- a/.claude/skills/deploy-analytics-dashboard/SKILL.md
+++ b/.claude/skills/deploy-analytics-dashboard/SKILL.md
@@ -166,7 +166,7 @@ If the pipeline fails at any stage, print the stage name and stop. Don't attempt
 ## Step 6: Verify the site
 
 ```bash
-curl -o /dev/null -s -w "%{http_code}" https://analytics-dashboard.dp.la
+curl -o /dev/null -s -w "%{http_code}" -A "Mozilla/5.0" https://analytics-dashboard.dp.la
 ```
 
 - `200` or `302` → success (302 is a redirect to the login page, which is normal)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,11 +40,12 @@ class ApplicationController < ActionController::Base
   end
   helper_method :admin_for_all_hubs?
 
-  # Encode literal slashes in hub/contributor names as %2F so they survive
-  # Rails' id: /[^\/]+/ route constraint during URL generation. The constraint
-  # prevents routing collisions but rejects raw "/" in path helper arguments.
+  # Double-encode slashes so they survive Rack's path decoding on the way in.
+  # Rack decodes %252F → %2F before routing (no literal slash, constraint passes),
+  # then Rails decodes %2F → / when setting params[:id]. Single %2F fails because
+  # Rack decodes it to a literal slash which breaks the [^\/]+ route constraint.
   def route_id(name)
-    name.to_s.gsub("/", "%2F")
+    name.to_s.gsub("/", "%252F")
   end
   helper_method :route_id
 

--- a/app/lib/dpla_api_response_builder.rb
+++ b/app/lib/dpla_api_response_builder.rb
@@ -16,7 +16,7 @@ class DplaApiResponseBuilder
     return {} if ids.empty?
 
     result = {}
-    ids.uniq.compact.each_slice(50) do |batch|
+    ids.filter_map { |id| id&.strip.presence }.uniq.each_slice(50) do |batch|
       begin
         docs = json_response("/items/#{batch.join(',')}", query: { api_key: api_key })['docs'] || []
         docs.each do |doc|

--- a/app/lib/website_events_presenter.rb
+++ b/app/lib/website_events_presenter.rb
@@ -23,11 +23,11 @@ class WebsiteEventsPresenter  < GaResponsePresenter
   end
 
   def id(row)
-    row[columns.index("ga:eventLabel")].split(" : ").first rescue nil
+    row[columns.index("ga:eventLabel")].split(" : ").first&.strip rescue nil
   end
 
   def title(row)
-    row[columns.index("ga:eventLabel")].split(" : ").last rescue nil
+    row[columns.index("ga:eventLabel")].split(" : ").last&.strip rescue nil
   end
 
   def count(row)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,9 @@
     <%= stylesheet_link_tag 'application', media: 'all', 
       'data-turbo-track': 'reload' %>
 
-    <%= javascript_include_tag 'application', 
-      'data-turbo-track': 'reload' %>
+    <%= javascript_include_tag 'application',
+      'data-turbo-track': 'reload',
+      'data-turbo-eval': 'false' %>
 
     <%= favicon_link_tag '/assets/dpla-favicon-black.png' %>
 

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -9,7 +9,8 @@
       'data-turbo-track': 'reload' %>
 
     <%= javascript_include_tag 'application',
-      'data-turbo-track': 'reload' %>
+      'data-turbo-track': 'reload',
+      'data-turbo-eval': 'false' %>
 
     <%= favicon_link_tag '/assets/dpla-favicon-black.png' %>
 

--- a/public/404.html
+++ b/public/404.html
@@ -3,6 +3,7 @@
 <head>
   <title>Page Not Found — DPLA Analytics Dashboard</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="icon" href="/assets/dpla-favicon-black.png">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {

--- a/public/422.html
+++ b/public/422.html
@@ -3,6 +3,7 @@
 <head>
   <title>Request Not Accepted — DPLA Analytics Dashboard</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="icon" href="/assets/dpla-favicon-black.png">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -52,6 +53,7 @@
     <div class="heading"><h1>Request Not Accepted</h1></div>
     <div class="body">
       <p>The request could not be processed.</p>
+      <p><a href="/">Return to the Analytics Dashboard</a></p>
       <p style="color: #666;">This may be caused by an expired or missing security token. Try navigating back and refreshing the page. Contact <a href="mailto:analytics-dashboard@dp.la">analytics-dashboard@dp.la</a> if the problem persists.</p>
     </div>
   </main>

--- a/public/500.html
+++ b/public/500.html
@@ -3,6 +3,7 @@
 <head>
   <title>Internal Server Error — DPLA Analytics Dashboard</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="icon" href="/assets/dpla-favicon-black.png">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -52,6 +53,7 @@
     <div class="heading"><h1>Something Went Wrong</h1></div>
     <div class="body">
       <p>An unexpected error occurred.</p>
+      <p><a href="/">Return to the Analytics Dashboard</a></p>
       <p style="color: #666;">Please try again in a few minutes. Contact <a href="mailto:analytics-dashboard@dp.la">analytics-dashboard@dp.la</a> if the problem persists.</p>
     </div>
   </main>

--- a/spec/lib/website_events_presenter_spec.rb
+++ b/spec/lib/website_events_presenter_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe WebsiteEventsPresenter do
+  let(:column_header) { double(name: 'ga:eventLabel') }
+  let(:ga_data) { double(column_headers: [column_header], rows: [], total_results: nil) }
+  let(:ga_response) { double(response: ga_data, multi_page_response: []) }
+  let(:presenter) { described_class.new(ga_response) }
+
+  describe '#id' do
+    it 'strips CRLF from item id' do
+      row = ["9ec935602492229f271b6611cdfd53a6\r\n : Some Title"]
+      expect(presenter.id(row)).to eq '9ec935602492229f271b6611cdfd53a6'
+    end
+
+    it 'returns nil when label is nil' do
+      row = [nil]
+      expect(presenter.id(row)).to be_nil
+    end
+  end
+
+  describe '#title' do
+    it 'strips CRLF from title' do
+      row = ["some-id : My Title\r\n"]
+      expect(presenter.title(row)).to eq 'My Title'
+    end
+
+    it 'returns nil when label is nil' do
+      row = [nil]
+      expect(presenter.title(row)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Fix `URI::InvalidURIError` for CRLF-contaminated GA event labels** — GA responses occasionally embed literal CRLF sequences in event label strings; Faraday raises `URI::InvalidURIError` when those are used as URL path segments. Strip `\r\n` from event label values before use. Adds a regression spec.

- **Fix routing and data loading for hub/contributor names containing `/`** — `route_id` was encoding slashes as `%2F`, but Rails' `escape_segment` then re-encoded the `%` to `%25`, so the async section URLs arrived at the controller with `params[:hub_id]` = `"NJ%2FDE..."` instead of `"NJ/DE..."`. `Hub.exists?` returned false and all data sections 404'd. Fix: encode as `%252F` so the chain resolves correctly. Affects NJ/DE Digital Collective (hub) and several Texas/Commonwealth contributors with slashes in their names.

- **Fix `submittersByForm` SyntaxError blocking data sections** — With `config.turbo = true` in render_async, all async sections wait for `turbo:load` before firing. Turbo was re-evaluating `application.js` during navigation, causing `const submittersByForm` in turbo.js to be re-declared and throw a SyntaxError, preventing `turbo:load` from ever firing. Fix: add `data-turbo-eval="false"` to the `javascript_include_tag` in both layouts.

- **Fix favicon and return links on static error pages** — `public/404.html`, `422.html`, and `500.html` had no favicon link (so the favicon disappeared on routing-level errors like URLs with literal slashes) and 422/500 had no way back to the dashboard.

## Test plan

- [ ] Visit `/hubs` as admin — NJ/DE Digital Collective hub card link renders without error
- [ ] Visit the NJ/DE Digital Collective hub page — all data sections load (website, API, BWS, metadata, Wikimedia)
- [ ] Navigate between hub pages using Turbo — data sections load on each page without JS errors in the console
- [ ] Visit a contributor with a slash in the name (e.g. under The Portal to Texas History) — page and data sections load correctly
- [ ] Visit a URL with a literal slash in the hub ID (e.g. `/hubs/NJ/DE%20Digital%20Collective`) — renders the static 404 page with favicon and a return link
- [ ] Confirm `public/422.html` and `public/500.html` also show the favicon and return link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Better normalization of item identifiers (ignores nil/blank/whitespace) and improved route encoding so URLs with slashes behave correctly.
  * Event label parsing now trims extraneous whitespace and safely handles missing/malformed labels.
  * Script inclusion adjusted to disable Turbo evaluation for the main JS bundle.

* **Tests**
  * Added unit tests covering event label parsing and identifier handling.

* **Documentation**
  * Deployment verification step now sends an explicit User-Agent.

* **Chores**
  * Error pages updated with a favicon and links back to the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->