### PR TITLE
Fix NJ/DE hub URL routing: canonical link 404s and sections data fails to load

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
   before_action :authenticate_user!
+  before_action :normalize_encoded_params
   before_action :redirect_inverted_date_range
   layout :layout_by_resource
 
@@ -8,6 +9,16 @@ class ApplicationController < ActionController::Base
               Timeout::Error, with: :handle_service_error
 
   private
+
+  ENCODED_PARAM_KEYS = %i[id hub_id contributor_id].freeze
+
+  def normalize_encoded_params
+    return unless request.get? || request.head?
+
+    ENCODED_PARAM_KEYS.each do |key|
+      params[key] = CGI.unescape(params[key]) if params[key]
+    end
+  end
 
   def redirect_inverted_date_range
     return unless request.get? || request.head?
@@ -40,12 +51,12 @@ class ApplicationController < ActionController::Base
   end
   helper_method :admin_for_all_hubs?
 
-  # Double-encode slashes so they survive Rack's path decoding on the way in.
-  # Rack decodes %252F → %2F before routing (no literal slash, constraint passes),
-  # then Rails decodes %2F → / when setting params[:id]. Single %2F fails because
-  # Rack decodes it to a literal slash which breaks the [^\/]+ route constraint.
+  # Encode literal slashes as %2F so the string passes Rails' [^\/]+ route
+  # constraint during URL generation. Rails' escape_segment then re-encodes
+  # the % to %25, producing %252F in the final URL. normalize_encoded_params
+  # runs a second CGI.unescape on inbound params to reverse that extra layer.
   def route_id(name)
-    name.to_s.gsub("/", "%252F")
+    name.to_s.gsub("/", "%2F")
   end
   helper_method :route_id
 


### PR DESCRIPTION
## Background

\"NJ/DE Digital Collective\" is the only hub whose name contains a literal `/`. That slash has caused a series of routing issues that have proven tricky to fix correctly. This PR is a follow-up to #283, which shipped in the April 27 deployment but did not resolve the problem.

## What #283 attempted (and why it failed)

#283 changed `route_id` to double-encode slashes (`/` → `%252F`) on the theory that Rack would decode `%25` → `%` on the way in, leaving `%2F` in `params`, which Rails would then decode to `/`. This was wrong.

Rails' `escape_segment` re-encodes the `%` in any pre-encoded string passed to a path helper. So the encoding chain was:

```
route_id("NJ/DE Digital Collective")  →  "NJ%252FDE Digital Collective"
escape_segment(...)                   →  "NJ%25252FDE%20Digital%20Collective"  (% → %25)
URL in browser                        →  /hubs/NJ%25252FDE%20Digital%20Collective
params[:hub_id] after Rails decode    →  "NJ%252FDE Digital Collective"  (≠ hub name)
→ Hub.exists? returns false → 404
```

The browser displays the URL with one level of percent-decoding, so the link on the `/hubs` page appears as `NJ%252FDE` — but the actual request was for a further-encoded form that didn't match any hub.

## Current state after the April 27 deployment

Three URLs, three different behaviors:

| URL | Behavior |
|-----|----------|
| `/hubs/NJ%252FDE%20Digital%20Collective` | **404** — this is what the `/hubs` index links to, and where hub-scoped users are redirected |
| `/hubs/NJ%2FDE%20Digital%20Collective` | **Page loads**, but the `/sections` XHR 404s (no data shown) |
| `/hubs/NJ%2FDE%20Digital%20Collective/sections` | **Loads fine** when accessed directly |

The page at `%2FDE` loads because it was typed manually in the browser — Rails decodes `%2F` → `/` in params, so the hub lookup succeeds. But the sections URL generated *on that page* uses `route_id`, which re-encodes the `/`, producing the double-encoded `%252FDE` form — which 404s.

## This fix

Two changes in `application_controller.rb`:

**1. Revert `route_id` to single `%2F` encoding:**

```ruby
def route_id(name)
  name.to_s.gsub("/", "%2F")
end
```

Passing `"NJ%2FDE Digital Collective"` (a string with the literal characters `%`, `2`, `F`) to a Rails path helper passes the `[^\/]+` route constraint check (no literal `/`). `escape_segment` then re-encodes the `%` to `%25`, so the final URL is `/hubs/NJ%252FDE%20Digital%20Collective`.

**2. Add `normalize_encoded_params` before_action:**

```ruby
ENCODED_PARAM_KEYS = %i[id hub_id contributor_id].freeze

def normalize_encoded_params
  return unless request.get? || request.head?
  ENCODED_PARAM_KEYS.each do |key|
    params[key] = CGI.unescape(params[key]) if params[key]
  end
end
```

When the canonical URL `/hubs/NJ%252FDE%20Digital%20Collective` comes in, Rails decodes params once: `params[:hub_id]` = `"NJ%2FDE Digital Collective"`. The before_action runs `CGI.unescape` a second time, converting `%2F` → `/` to produce the actual hub name `"NJ/DE Digital Collective"`. Hub lookups, authorization checks, and data queries all work correctly.

The single-encoded URL `/hubs/NJ%2FDE%20Digital%20Collective` also continues to work — `CGI.unescape` on a string with no `%XX` sequences is a no-op — so there is no regression for users who have bookmarked that form.

The before_action is GET/HEAD-only (matching the pattern of `redirect_inverted_date_range`) to avoid any risk of corrupting POST/PATCH form data.

## Test plan

- [ ] Visit `/hubs` — confirm the NJ/DE Digital Collective card link loads the hub page
- [ ] Confirm data sections load on the hub page (website use, API use, metadata, Wikimedia cards all populate)
- [ ] Log in as a hub-scoped NJ/DE user — confirm redirect lands on the correct hub page with data
- [ ] Spot-check another hub (e.g. Mountain West) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter decoding for GET/HEAD requests to correctly handle encoded characters in URL parameters, particularly for identifiers and IDs containing special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->