### PR TITLE
Fix code quality issues (AI findings)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
     return unless request.get? || request.head?
 
     ENCODED_PARAM_KEYS.each do |key|
-      params[key] = CGI.unescape(params[key]) if params[key]
+      params[key] = CGI.unescape(params[key]) if params[key].is_a?(String)
     end
   end
 
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_for_all_hubs?
-    current_user.admin && current_user.hub == "All"
+    current_user.admin? && current_user.hub == "All"
   end
   helper_method :admin_for_all_hubs?
 

--- a/app/lib/metadata_completeness.rb
+++ b/app/lib/metadata_completeness.rb
@@ -40,14 +40,14 @@ class MetadataCompleteness
 
   def hub_csv
     @hub_csv ||= Rails.cache.fetch("mc_csv:hub:#{@end_date}", expires_in: 24.hours) do
-      response = sThree_response("provider.csv")
+      response = s3_response("provider.csv")
       response ? csv_data(response).to_a : []
     end
   end
 
   def contributor_csv
     @contributor_csv ||= Rails.cache.fetch("mc_csv:contributor:#{@end_date}", expires_in: 24.hours) do
-      response = sThree_response("contributor.csv")
+      response = s3_response("contributor.csv")
       response ? csv_data(response).to_a : []
     end
   end
@@ -63,7 +63,7 @@ class MetadataCompleteness
   #
   # @return [Aws::S3::Types::GetObjectOutput, nil]
   #
-  def sThree_response(file_name)
+  def s3_response(file_name)
     date = @end_date
     response = nil
 
@@ -113,7 +113,7 @@ class MetadataCompleteness
   end
 
   ##
-  # Minimum data that data is expected to be available.
+  # Minimum date that data is expected to be available.
   # @return Date
   def min_date
     Date.new(Settings.mc_min_date.year.to_i, Settings.mc_min_date.month.to_i)

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -4,7 +4,7 @@
   function toggle_column(element) {
     var els = document.getElementsByClassName(element.value);
 
-    if (element.checked == true) {
+    if (element.checked) {
       Array.prototype.forEach.call(els, function(el) {
         el.style.display="table-cell";
       });

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,8 +8,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '64a8b3903da2d72835b4d4fe3b4b2081c9badfc50e67538ad8a967503e37ac18a589654877c1207e3018f09f44d84c6b1f51ab676174b04830da9ee0476ad26a'
-  
+
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'
@@ -114,7 +113,6 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = 'd2d18e649f854a39e1d5b7eb986d668d19494684c0795102013c2eb8d741e02f4cce4b2b1f92a1a147502cae7e6125d42ffea00469e9299e2e1dc6e93e989abb'
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false
@@ -257,22 +255,6 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-
-  # ==> Warden configuration
-  # Warden 1.2.9 raises "Invalid strategy <name>" for any Devise module included
-  # in the scope's strategy list that has no Warden::Strategies registration.
-  # :database_authenticatable and :rememberable are real Warden strategies;
-  # the others (:recoverable, :trackable, :validatable) are Devise-only modules
-  # that need no-op stubs so Warden can look them up without raising.
-  # Remove once Devise is upgraded to 5.x.
-  config.warden do |manager|
-    %i[recoverable trackable validatable].each do |strategy|
-      manager.strategies.add(strategy) do
-        def valid?; false; end
-        def authenticate!; pass; end
-      end unless Warden::Strategies[strategy]
-    end
-  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine


### PR DESCRIPTION
## Summary

- **`application_controller.rb`**: Guard `CGI.unescape` with `is_a?(String)` to handle non-string param values; use `admin?` in `admin_for_all_hubs?` to guarantee boolean return (`admin &&` returns `nil` instead of `false` when the column is nil)
- **`devise.rb`**: Remove commented-out `secret_key` and `pepper` values (sensitive data in VCS); remove Devise 4.x Warden no-op strategy workaround — now on Devise 5.0.3
- **`metadata_completeness.rb`**: Rename `sThree_response` → `s3_response` (inconsistent camelCase); fix comment typo "data" → "date"
- **`contributors/index.html.erb`**: Simplify `element.checked == true` → `element.checked`

## Not actioned

- `redirect_to "#{request.path}?..."` flagged as open redirect — false positive; `request.path` is always the server's own `/`-prefixed path and cannot redirect to an external domain
- `current_end_date` missing `params[:end_date].present?` guard — intentional; `@end_date` is always set by `DateSetter` (defaults to today), so the asymmetry with `current_start_date` is by design

## Test plan

- [ ] Auth flow works (Devise 5.x Warden workaround removal)
- [ ] `admin_for_all_hubs?` returns `false` (not `nil`) for non-admin users
- [ ] Metadata completeness pages load correctly (`s3_response` rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved parameter handling to correctly process string-encoded values
  * Updated authorization verification for admin access checks

* **Refactor**
  * Optimized cloud storage CSV retrieval mechanism
  * Simplified client-side column toggle logic
  * Removed obsolete authentication configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->