### PR TITLE
Fix DPLA API base_uri missing https:// scheme

### DIFF
--- a/config/settings.yml.template
+++ b/config/settings.yml.template
@@ -8,12 +8,12 @@ google_analytics:
   tracking_id: <%= ENV["TRACKING_ID"] %>
 
 dpla_api:
-  # include trailing backslash
-  base_uri: api.dp.la/v2/
+  # include trailing slash
+  base_uri: https://api.dp.la/v2/
   key: <%= ENV["DPLA_API_KEY"] %>
 
 dpla:
-  # include trailing backslash
+  # include trailing slash
   base_uri: https://dp.la/
 
 s3:


### PR DESCRIPTION
## Summary

- `config/settings.yml.template` had `base_uri: api.dp.la/v2/` with no URL scheme, causing HTTParty to default to `http://` and connect to `api.dp.la:80`
- `api.dp.la` only serves HTTPS; port 80 is silently dropped, resulting in `Net::OpenTimeout` errors
- Fixed by adding the `https://` scheme; also corrected a stale "backslash" → "slash" comment in the same file

The error surfaced in `DplaApiResponseBuilder#data_providers_for_items`, which looks up `dataProvider` names for items shown in the hub-level website events table. The exception is caught and Sentry-reported, so users saw a degraded events table (missing contributor names) rather than a 500. Only 5 Sentry events total — this code path requires a hub-level (not contributor-scoped) events view with non-empty GA results.

**Note for the next deploy:** since `settings.yml` is baked into the Docker image at build time (it's gitignored but not dockerignored), the local `config/settings.yml` will also need to be updated before the next ECR build.

## Test plan

- [ ] Update local `config/settings.yml` to use `https://api.dp.la/v2/` before rebuilding the Docker image
- [ ] Verify the Michigan Hub click-through events table loads contributor names correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DPLA API configuration to use HTTPS endpoint.
  * Clarified configuration documentation for API endpoint formatting requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dpla/dashboard-analytics/pull/311)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->