### PR TITLE
item tables: default to full-range, and cutoff mid-2025

### DIFF
--- a/app/controllers/concerns/date_setter.rb
+++ b/app/controllers/concerns/date_setter.rb
@@ -1,6 +1,11 @@
 module DateSetter
   extend ActiveSupport::Concern
 
+  included do
+    # Date menu needs the bounds the controller clamps to.
+    helper_method :min_date, :max_date
+  end
+
   def min_date
     DataWindow.min_date
   end
@@ -49,7 +54,8 @@ module DateSetter
   # and params[:end_date], both of which are expected to be in the format
   # "YYYY-MM"
   # With a start date but no end date, @end_date is the end of the start month.
-  # With neither, both dates fall back to the last completed month.
+  # With neither, both fall back to the defaults, which a controller can
+  # widen via default_start_date (see EventsController).
   # DateSetter has access to controller params and instance variables.
   #
   def assign_start_and_end_dates
@@ -61,8 +67,10 @@ module DateSetter
       end_year = parse_year(params[:end_date])
       end_month = parse_month(params[:end_date])
       @end_date = end_of_month(end_year, end_month)
-    else
+    elsif params[:start_date].present?
       @end_date = end_of_month(@start_date.year, @start_date.month)
+    else
+      @end_date = default_end_date
     end
 
     @end_date = default_end_date if @end_date < @start_date

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -65,4 +65,16 @@ class EventsController < ApplicationController
       format.csv { send_data @events.to_csv }
     end
   end
+
+  private
+
+  # Event tables have no rows before event_label (see DataWindow).
+  def min_date
+    DataWindow.events_min_date
+  end
+
+  # No dates in the URL: show the full window, not one month.
+  def default_start_date
+    min_date
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -69,6 +69,8 @@ class EventsController < ApplicationController
   private
 
   # Event tables have no rows before event_label (see DataWindow).
+  # Also floors api_events, harmless while ApiEvents#response is stubbed nil;
+  # revisit if API event tracking returns.
   def min_date
     DataWindow.events_min_date
   end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -26,13 +26,15 @@ module DateHelper
 
   ##
   # @return [Array<Date>] the first day of every month in the display
-  #   window (see DataWindow)
+  #   window, min_date..max_date, which a controller may narrow
+  #   (see EventsController#min_date)
   def available_months
-    first_date = DataWindow.min_date
-    last_date = DataWindow.max_date.beginning_of_month
-    dates = [first_date]
-    dates.push(dates.last.next_month) while dates.last < last_date
-    dates
+    @available_months ||= begin
+      last_date = max_date.beginning_of_month
+      dates = [min_date]
+      dates.push(dates.last.next_month) while dates.last < last_date
+      dates
+    end
   end
 
   def website_data_start_date

--- a/app/jobs/warm_comparison_cache_job.rb
+++ b/app/jobs/warm_comparison_cache_job.rb
@@ -87,18 +87,24 @@ class WarmComparisonCacheJob < ApplicationJob
     event_failures
   end
 
-  # First page of each event table, default view (last completed month).
+  # First page of each event table, for both landing ranges: the default
+  # full window (see EventsController#default_start_date) and the last
+  # completed month alone, which the date menu and old links request.
   # Other ranges: stored on first user request. Counts nil responses;
   # WebsiteEvents#response swallows errors.
   def warm_event_tables(hub_name, end_date)
-    WebsiteEvents::NAMES_BY_ID.each_value.count do |event_name|
-      WebsiteEvents.build do |b|
-        b.hub        = hub_name
-        b.start_date = end_date.beginning_of_month
-        b.end_date   = end_date
-        b.event_name = event_name
-        b.page       = 1
-      end.response.nil?
+    starts = [DataWindow.events_min_date, end_date.beginning_of_month].uniq
+
+    starts.sum do |start_date|
+      WebsiteEvents::NAMES_BY_ID.each_value.count do |event_name|
+        WebsiteEvents.build do |b|
+          b.hub        = hub_name
+          b.start_date = start_date
+          b.end_date   = end_date
+          b.event_name = event_name
+          b.page       = 1
+        end.response.nil?
+      end
     end
   end
 end

--- a/app/lib/data_window.rb
+++ b/app/lib/data_window.rb
@@ -10,11 +10,22 @@ module DataWindow
 
   # First day of the earliest month with data.
   def min_date
-    Date.new(Settings.min_date.year.to_i, Settings.min_date.month.to_i)
+    month_start(Settings.min_date)
+  end
+
+  # First day of the earliest month with per-item event data. GA4 registered
+  # the event_label dimension Jul 18, 2025; earlier months return no rows.
+  def events_min_date
+    month_start(Settings.events_min_date)
   end
 
   # Last day of the last completed month.
   def max_date
     Date.current.beginning_of_month - 1
+  end
+
+  # Settings floors are { month:, year: }.
+  def month_start(setting)
+    Date.new(setting.year.to_i, setting.month.to_i)
   end
 end

--- a/config/settings.yml.template
+++ b/config/settings.yml.template
@@ -24,6 +24,12 @@ min_date:
   month: 01
   year: 2018
 
+# Minimum date for which per-item event data is available; GA4 registered
+# the event_label dimension Jul 18, 2025
+events_min_date:
+  month: 07
+  year: 2025
+
 # Minimum date for which api usage data is available
 api_min_date:
   month: 05

--- a/spec/lib/date_setter_spec.rb
+++ b/spec/lib/date_setter_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 describe DateSetter do
   let(:host_class) do
     Class.new do
+      # Stand in for the one controller method DateSetter calls on include.
+      def self.helper_method(*); end
+
       include DateSetter
       attr_accessor :params
 
@@ -43,6 +46,23 @@ describe DateSetter do
 
     it 'clamps a range entirely in the current month to the last completed month' do
       host.params = { start_date: '2026-07', end_date: '2026-07' }
+      expect(assigned_dates).to eq [Date.new(2026, 6, 1), Date.new(2026, 6, 30)]
+    end
+
+    it 'uses the full window when the host widens default_start_date' do
+      allow(host).to receive(:default_start_date).and_return(Date.new(2025, 7, 1))
+      expect(assigned_dates).to eq [Date.new(2025, 7, 1), Date.new(2026, 6, 30)]
+    end
+
+    it 'clamps a start date before min_date to the default start' do
+      allow(host).to receive(:min_date).and_return(Date.new(2025, 7, 1))
+      allow(host).to receive(:default_start_date).and_return(Date.new(2025, 7, 1))
+      host.params = { start_date: '2019-07', end_date: '2026-03' }
+      expect(assigned_dates).to eq [Date.new(2025, 7, 1), Date.new(2026, 3, 31)]
+    end
+
+    it 'keeps the one-month default when only an end date is given' do
+      host.params = { end_date: '2026-03' }
       expect(assigned_dates).to eq [Date.new(2026, 6, 1), Date.new(2026, 6, 30)]
     end
   end


### PR DESCRIPTION
On our item table views (website click throughts, catalog views, etc.), previously we had the table show the last month's data by default. However, there were two points of confusion:
* The date selection dropdowns would default to the full range of time (2018 to present) even though only the last month's data was being shown.
* That experience differs from the main overview page, which does show complete data from all time.

With this PR:
* The item tables now default to showing the full date range, making it consistent with the default dropdown values and overview page.
* The earliest available dropdown date is now July 2025, as we do no longer have data from before then to show.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Event reporting supports a configurable historical date range, beginning July 2025 by default.
  * Date selectors automatically apply suitable start and end dates.
  * Date ranges are limited to periods with available event data.
* **Improvements**
  * Event data for the full available period and latest completed month is prepared for faster access.
* **Tests**
  * Added coverage for date defaults, limits, and partial date selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->