### PR TITLE
For item names, split on only the first colon

### DIFF
--- a/app/lib/api_events_presenter.rb
+++ b/app/lib/api_events_presenter.rb
@@ -16,11 +16,13 @@ class ApiEventsPresenter < GaResponsePresenter
 
   # Labels are "id : title". Split once; the title may contain " : ".
   def id(row)
-    row[columns.index("ga:eventLabel")].split(" : ", 2).first rescue nil
+    label_index = columns.index("ga:eventLabel")
+    row[label_index]&.split(" : ", 2)&.first if label_index
   end
 
   def title(row)
-    row[columns.index("ga:eventLabel")].split(" : ", 2).last rescue nil
+    label_index = columns.index("ga:eventLabel")
+    row[label_index]&.split(" : ", 2)&.last if label_index
   end
 
   def count(row)

--- a/app/lib/api_events_presenter.rb
+++ b/app/lib/api_events_presenter.rb
@@ -14,12 +14,13 @@ class ApiEventsPresenter < GaResponsePresenter
     row[columns.index("ga:eventAction")]
   end
 
+  # Labels are "id : title". Split once; the title may contain " : ".
   def id(row)
-    row[columns.index("ga:eventLabel")].split(" : ").first rescue nil
+    row[columns.index("ga:eventLabel")].split(" : ", 2).first rescue nil
   end
 
   def title(row)
-    row[columns.index("ga:eventLabel")].split(" : ").last rescue nil
+    row[columns.index("ga:eventLabel")].split(" : ", 2).last rescue nil
   end
 
   def count(row)

--- a/app/lib/api_events_presenter.rb
+++ b/app/lib/api_events_presenter.rb
@@ -16,13 +16,11 @@ class ApiEventsPresenter < GaResponsePresenter
 
   # Labels are "id : title". Split once; the title may contain " : ".
   def id(row)
-    label_index = columns.index("ga:eventLabel")
-    row[label_index]&.split(" : ", 2)&.first if label_index
+    event_label(row)&.split(" : ", 2)&.first
   end
 
   def title(row)
-    label_index = columns.index("ga:eventLabel")
-    row[label_index]&.split(" : ", 2)&.last if label_index
+    event_label(row)&.split(" : ", 2)&.last
   end
 
   def count(row)

--- a/app/lib/api_events_presenter.rb
+++ b/app/lib/api_events_presenter.rb
@@ -14,15 +14,6 @@ class ApiEventsPresenter < GaResponsePresenter
     row[columns.index("ga:eventAction")]
   end
 
-  # Labels are "id : title". Split once; the title may contain " : ".
-  def id(row)
-    event_label(row)&.split(" : ", 2)&.first
-  end
-
-  def title(row)
-    event_label(row)&.split(" : ", 2)&.last
-  end
-
   def count(row)
     row[columns.index("ga:totalEvents")]
   end

--- a/app/lib/ga_response_presenter.rb
+++ b/app/lib/ga_response_presenter.rb
@@ -26,4 +26,10 @@ class GaResponsePresenter
   def rows
     response && response.rows ? response.rows : []
   end
+
+  # nil when the row has no label or the report omits the column.
+  def event_label(row)
+    index = columns.index("ga:eventLabel")
+    row[index] if index
+  end
 end

--- a/app/lib/ga_response_presenter.rb
+++ b/app/lib/ga_response_presenter.rb
@@ -32,4 +32,14 @@ class GaResponsePresenter
     index = columns.index("ga:eventLabel")
     row[index] if index
   end
+
+  # Labels are "id : title". Split once; the title may contain " : ".
+  # GA has sent labels with embedded CRLF, hence the strip.
+  def id(row)
+    event_label(row)&.split(" : ", 2)&.first&.strip
+  end
+
+  def title(row)
+    event_label(row)&.split(" : ", 2)&.last&.strip
+  end
 end

--- a/app/lib/website_events_presenter.rb
+++ b/app/lib/website_events_presenter.rb
@@ -22,15 +22,6 @@ class WebsiteEventsPresenter  < GaResponsePresenter
     lookup[id(row)] || row[columns.index("ga:eventAction")]
   end
 
-  # Labels are "id : title". Split once; the title may contain " : ".
-  def id(row)
-    event_label(row)&.split(" : ", 2)&.first&.strip
-  end
-
-  def title(row)
-    event_label(row)&.split(" : ", 2)&.last&.strip
-  end
-
   def count(row)
     row[columns.index("ga:totalEvents")]
   end

--- a/app/lib/website_events_presenter.rb
+++ b/app/lib/website_events_presenter.rb
@@ -24,11 +24,13 @@ class WebsiteEventsPresenter  < GaResponsePresenter
 
   # Labels are "id : title". Split once; the title may contain " : ".
   def id(row)
-    row[columns.index("ga:eventLabel")].split(" : ", 2).first&.strip rescue nil
+    label_index = columns.index("ga:eventLabel")
+    row[label_index]&.split(" : ", 2)&.first&.strip if label_index
   end
 
   def title(row)
-    row[columns.index("ga:eventLabel")].split(" : ", 2).last&.strip rescue nil
+    label_index = columns.index("ga:eventLabel")
+    row[label_index]&.split(" : ", 2)&.last&.strip if label_index
   end
 
   def count(row)

--- a/app/lib/website_events_presenter.rb
+++ b/app/lib/website_events_presenter.rb
@@ -24,13 +24,11 @@ class WebsiteEventsPresenter  < GaResponsePresenter
 
   # Labels are "id : title". Split once; the title may contain " : ".
   def id(row)
-    label_index = columns.index("ga:eventLabel")
-    row[label_index]&.split(" : ", 2)&.first&.strip if label_index
+    event_label(row)&.split(" : ", 2)&.first&.strip
   end
 
   def title(row)
-    label_index = columns.index("ga:eventLabel")
-    row[label_index]&.split(" : ", 2)&.last&.strip if label_index
+    event_label(row)&.split(" : ", 2)&.last&.strip
   end
 
   def count(row)

--- a/app/lib/website_events_presenter.rb
+++ b/app/lib/website_events_presenter.rb
@@ -22,12 +22,13 @@ class WebsiteEventsPresenter  < GaResponsePresenter
     lookup[id(row)] || row[columns.index("ga:eventAction")]
   end
 
+  # Labels are "id : title". Split once; the title may contain " : ".
   def id(row)
-    row[columns.index("ga:eventLabel")].split(" : ").first&.strip rescue nil
+    row[columns.index("ga:eventLabel")].split(" : ", 2).first&.strip rescue nil
   end
 
   def title(row)
-    row[columns.index("ga:eventLabel")].split(" : ").last&.strip rescue nil
+    row[columns.index("ga:eventLabel")].split(" : ", 2).last&.strip rescue nil
   end
 
   def count(row)

--- a/spec/lib/api_events_presenter_spec.rb
+++ b/spec/lib/api_events_presenter_spec.rb
@@ -16,6 +16,11 @@ describe ApiEventsPresenter do
       row = [nil]
       expect(presenter.id(row)).to be_nil
     end
+
+    it 'returns nil when the label column is missing' do
+      allow(column_header).to receive(:name).and_return('ga:other')
+      expect(presenter.id(['some-id : Title'])).to be_nil
+    end
   end
 
   describe '#title' do

--- a/spec/lib/api_events_presenter_spec.rb
+++ b/spec/lib/api_events_presenter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe ApiEventsPresenter do
+  let(:column_header) { double(name: 'ga:eventLabel') }
+  let(:ga_data) { double(column_headers: [column_header], rows: [], total_results: nil) }
+  let(:ga_response) { double(response: ga_data, multi_page_response: []) }
+  let(:presenter) { described_class.new(ga_response) }
+
+  describe '#id' do
+    it 'returns the id before the separator' do
+      row = ['9ec935602492229f271b6611cdfd53a6 : Some Title']
+      expect(presenter.id(row)).to eq '9ec935602492229f271b6611cdfd53a6'
+    end
+
+    it 'returns nil when label is nil' do
+      row = [nil]
+      expect(presenter.id(row)).to be_nil
+    end
+  end
+
+  describe '#title' do
+    it 'returns the title after the separator' do
+      row = ['some-id : My Title']
+      expect(presenter.title(row)).to eq 'My Title'
+    end
+
+    it 'returns nil when label is nil' do
+      row = [nil]
+      expect(presenter.title(row)).to be_nil
+    end
+
+    it 'keeps a title containing the separator intact' do
+      row = ['some-id : Blueberry : Pie']
+      expect(presenter.title(row)).to eq 'Blueberry : Pie'
+    end
+  end
+end

--- a/spec/lib/website_events_presenter_spec.rb
+++ b/spec/lib/website_events_presenter_spec.rb
@@ -16,6 +16,11 @@ describe WebsiteEventsPresenter do
       row = [nil]
       expect(presenter.id(row)).to be_nil
     end
+
+    it 'returns nil when the label column is missing' do
+      allow(column_header).to receive(:name).and_return('ga:other')
+      expect(presenter.id(['some-id : Title'])).to be_nil
+    end
   end
 
   describe '#title' do

--- a/spec/lib/website_events_presenter_spec.rb
+++ b/spec/lib/website_events_presenter_spec.rb
@@ -28,6 +28,11 @@ describe WebsiteEventsPresenter do
       row = [nil]
       expect(presenter.title(row)).to be_nil
     end
+
+    it 'keeps a title containing the separator intact' do
+      row = ['some-id : Blueberry : Pie']
+      expect(presenter.title(row)).to eq 'Blueberry : Pie'
+    end
   end
 
   describe 'contributor resolution' do


### PR DESCRIPTION
Currently we get item data as "ID : Human readable name". To pull the human readable name out, we would split on the colon. The issue is that for names that include a colon (e.g. "ID : Blueberry : Pie"), the split would cause the item name to be detected as just "Pie". This PR fixes this by only splitting on the first colon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event titles containing additional separators are now displayed in full.
  * Event identifiers and titles safely handle missing labels while preserving whitespace trimming.
  * Event data from Google Analytics responses now consistently includes parsed identifiers and titles.

* **Tests**
  * Added coverage for event identifier and title parsing, including missing labels and embedded separators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->