### PR TITLE
Calculate earliest month for date selection

### DIFF
--- a/app/controllers/concerns/date_setter.rb
+++ b/app/controllers/concerns/date_setter.rb
@@ -3,11 +3,16 @@ module DateSetter
 
   included do
     # Date menu needs the bounds the controller clamps to.
-    helper_method :min_date, :max_date
+    helper_method :min_date, :max_date, :picker_min_date
   end
 
   def min_date
     DataWindow.min_date
+  end
+
+  # Date-menu floor only; queries keep min_date. See GaDataFloor.
+  def picker_min_date
+    min_date
   end
 
   # Last day of the last completed month (see DataWindow).

--- a/app/controllers/concerns/ga_data_floor.rb
+++ b/app/controllers/concerns/ga_data_floor.rb
@@ -1,0 +1,50 @@
+##
+# Date-menu floor for GA4 pages: earliest month with data.
+# GA4 starts mid-2025, years after Settings.min_date.
+# Menu only: queries and clamping keep min_date, so cache keys and old
+# links are unchanged.
+#
+module GaDataFloor
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :ga4_earliest_month
+  end
+
+  # Capped at default_start_date: the menu must offer it.
+  def picker_min_date
+    @picker_min_date ||= [earliest_data_month || min_date, default_start_date].min
+  end
+
+  ##
+  # First month with GA4 activity; site-wide when no hub or contributor.
+  # nil when unknown: no data, or the query failed.
+  #
+  def ga4_earliest_month
+    return @ga4_earliest_month if defined?(@ga4_earliest_month)
+
+    @ga4_earliest_month = WebsiteActivityMonths.build do |b|
+      b.hub         = ga4_floor_hub
+      b.contributor = ga4_floor_contributor
+      b.start_date  = min_date
+      # Not max_date: always S3-storable, so the first days of a month
+      # hit last month's stored entry, not live GA4.
+      b.end_date    = GaPersistentCache.settled_boundary - 1
+    end.earliest_month
+  end
+
+  private
+
+  # Override where a page also shows non-GA4 data (see HubsController).
+  def earliest_data_month
+    ga4_earliest_month
+  end
+
+  def ga4_floor_hub
+    params[:hub_id]
+  end
+
+  def ga4_floor_contributor
+    params[:contributor_id]
+  end
+end

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -3,6 +3,7 @@
 class ContributorsController < ApplicationController
   # Controller concerns
   include DateSetter
+  include GaDataFloor
   # View helpers
   include DataMenuHelper
   include DateHelper
@@ -410,6 +411,30 @@ class ContributorsController < ApplicationController
   end
 
   private
+
+  helper_method :wikimedia_start_date
+
+  # First month with Wikimedia data; nil when none. Hub-level on index.
+  def wikimedia_start_date
+    return @wikimedia_start_date if defined?(@wikimedia_start_date)
+
+    hub_id      = params[:hub_id]
+    contributor = ga4_floor_contributor.to_s
+    key = "wikimedia_start_month:#{hub_id}:#{contributor}"
+    first_month = Rails.cache.fetch(key, expires_in: 24.hours) do
+      WikimediaCache.where(hub: hub_id, contributor: contributor).minimum(:month)
+    end
+    @wikimedia_start_date = first_month && Date.parse("#{first_month}-01")
+  end
+
+  def ga4_floor_contributor
+    params[:contributor_id] || params[:id]
+  end
+
+  # Wikimedia predates GA4 and shares this picker.
+  def earliest_data_month
+    [ga4_earliest_month, wikimedia_start_date].compact.min
+  end
 
   # One page of the hub's contributors
   def page_of_contributors(hub_id)

--- a/app/controllers/hubs_controller.rb
+++ b/app/controllers/hubs_controller.rb
@@ -3,6 +3,7 @@
 class HubsController < ApplicationController
   # Controller concerns
   include DateSetter
+  include GaDataFloor
   # View helpers
   include DataMenuHelper
   include DateHelper
@@ -28,11 +29,6 @@ class HubsController < ApplicationController
     assign_start_and_end_dates
     @hub = Hub.new(params[:id], @start_date, @end_date)
 
-    first_month = Rails.cache.fetch("wikimedia_start_month:#{params[:id]}", expires_in: 24.hours) do
-      WikimediaCache.where(hub: params[:id], contributor: "").minimum(:month)
-    end
-    @wikimedia_start_date = Date.parse("#{first_month}-01") if first_month
-
     # Pre-load S3-cached counts so the totals card renders on initial page load.
     @item_count        = Hub.item_count(params[:id])
     @contributor_count = Hub.contributor_count(params[:id])
@@ -50,11 +46,6 @@ class HubsController < ApplicationController
     all_start, all_end  = min_date, max_date
     sec_start, sec_end  = section_date_range
     end_date            = @end_date
-
-    first_month = Rails.cache.fetch("wikimedia_start_month:#{hub_id}", expires_in: 24.hours) do
-      WikimediaCache.where(hub: hub_id, contributor: "").minimum(:month)
-    end
-    @wikimedia_start_date = Date.parse("#{first_month}-01") if first_month
 
     @item_count        = Hub.item_count(hub_id)
     @contributor_count = Hub.contributors(hub_id).size
@@ -257,6 +248,28 @@ class HubsController < ApplicationController
   end
 
   private
+
+  helper_method :wikimedia_start_date
+
+  # First month with Wikimedia data; nil when none.
+  def wikimedia_start_date
+    return @wikimedia_start_date if defined?(@wikimedia_start_date)
+
+    hub_id = params[:hub_id] || params[:id]
+    first_month = Rails.cache.fetch("wikimedia_start_month:#{hub_id}", expires_in: 24.hours) do
+      WikimediaCache.where(hub: hub_id, contributor: "").minimum(:month)
+    end
+    @wikimedia_start_date = first_month && Date.parse("#{first_month}-01")
+  end
+
+  def ga4_floor_hub
+    params[:hub_id] || params[:id]
+  end
+
+  # Wikimedia predates GA4 and shares this picker.
+  def earliest_data_month
+    [ga4_earliest_month, wikimedia_start_date].compact.min
+  end
 
   def authorize_hub_scope!
     return render_not_found unless Hub.exists?(params[:hub_id])

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -3,6 +3,7 @@
 class LocationsController < ApplicationController
   # Controller concerns
   include DateSetter
+  include GaDataFloor
   # View helpers
   include DataMenuHelper
   include DateHelper

--- a/app/controllers/search_terms_controller.rb
+++ b/app/controllers/search_terms_controller.rb
@@ -3,6 +3,8 @@
 class SearchTermsController < ApplicationController
   # Controller concerns
   include DateSetter
+  # Site-wide floor: no hub or contributor params.
+  include GaDataFloor
   # View helpers
   include DataMenuHelper
   include DateHelper

--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -3,6 +3,7 @@
 class TimelinesController < ApplicationController
   # Controller concerns
   include DateSetter
+  include GaDataFloor
   # View helpers
   include DataMenuHelper
   include DateHelper

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -25,23 +25,22 @@ module DateHelper
   end
 
   ##
-  # @return [Array<Date>] the first day of every month in the display
-  #   window, min_date..max_date, which a controller may narrow
-  #   (see EventsController#min_date)
+  # @return [Array<Date>] first day of every month from picker_min_date
+  #   to max_date (narrowed by EventsController#min_date, GaDataFloor)
   def available_months
     @available_months ||= begin
       last_date = max_date.beginning_of_month
-      dates = [min_date]
+      dates = [picker_min_date]
       dates.push(dates.last.next_month) while dates.last < last_date
       dates
     end
   end
 
-  def website_data_start_date
-    DataWindow.min_date
+  # Date-menu bounds, e.g. "Jun 2026".
+  def data_available_from
+    picker_min_date.strftime("%b %Y")
   end
 
-  # Date-menu note, e.g. "Jun 2026" (the menu's "%b %Y" format).
   def data_available_through
     DataWindow.max_date.strftime("%b %Y")
   end

--- a/app/jobs/warm_comparison_cache_job.rb
+++ b/app/jobs/warm_comparison_cache_job.rb
@@ -35,6 +35,13 @@ class WarmComparisonCacheJob < ApplicationJob
       Sentry.capture_exception(e)
     end
 
+    # Site-wide floor for the search-terms page.
+    site_months = WebsiteActivityMonths.build do |b|
+      b.start_date = DataWindow.min_date
+      b.end_date   = end_date
+    end
+    failures += 1 if site_months.response.nil?
+
     summary = "WarmComparisonCacheJob: warmed #{hubs.size} hubs, #{failures} failures"
     Rails.logger.info(summary)
     Sentry.capture_message(summary) if failures.positive?
@@ -48,11 +55,13 @@ class WarmComparisonCacheJob < ApplicationJob
   def warm_hub(hub_name, start_date, end_date)
     Rails.logger.info("WarmComparisonCacheJob: warming cache for #{hub_name}")
 
+    # Five entries: the batchRunReports cap.
     sections = [
       [WebsiteOverviewByContributor, end_date.beginning_of_month],
       [WebsiteEventsByContributor,   end_date.beginning_of_month],
       [WebsiteOverview,              start_date],
       [WebsiteEventTotals,           start_date],
+      [WebsiteActivityMonths,        start_date],
     ].map do |klass, range_start|
       klass.build do |b|
         b.hub        = hub_name

--- a/app/lib/ga_persistent_cache.rb
+++ b/app/lib/ga_persistent_cache.rb
@@ -98,7 +98,8 @@ class GaPersistentCache
     response.first.total_results.to_i > fetched
   end
 
-  # First day of the earliest month still subject to change.
+  # First day of the earliest month still subject to change. Public for
+  # GaDataFloor.
   def self.settled_boundary
     (Date.current - SETTLING_DAYS).beginning_of_month
   end
@@ -140,7 +141,7 @@ class GaPersistentCache
     )
   end
 
-  private_class_method :read, :truncated?, :settled_boundary, :s3_key,
+  private_class_method :read, :truncated?, :s3_key,
                        :serialize, :serialize_response,
                        :deserialize, :deserialize_response
 

--- a/app/lib/website_activity_months.rb
+++ b/app/lib/website_activity_months.rb
@@ -1,0 +1,96 @@
+##
+# Months with dp.la activity, from one GA4 report keyed by yearMonth.
+# Feeds the date-menu floor (see GaDataFloor).
+#
+class WebsiteActivityMonths
+  include GaErrorTracking
+  include GaCacheable
+
+  ##
+  # @return [WebsiteActivityMonths]
+  #
+  # @example
+  #   WebsiteActivityMonths.build do |builder|
+  #     builder.hub = "California Digital Library"
+  #     builder.start_date = Date.new(2018, 1, 1)
+  #     builder.end_date = Date.new(2026, 6, 30)
+  #   end
+  #
+  def self.build
+    builder = new
+    yield(builder)
+    builder
+  end
+
+  def initialize
+    @hub = nil
+    @contributor = nil
+    @start_date = nil
+    @end_date = nil
+  end
+
+  def hub=(hub)
+    @hub = hub
+  end
+
+  def contributor=(contributor)
+    @contributor = contributor
+  end
+
+  def start_date=(start_date)
+    @start_date = start_date
+  end
+
+  def end_date=(end_date)
+    @end_date = end_date
+  end
+
+  # Memoized builder for the warm job's batched GA4 calls.
+  def ga_builder
+    @ga_builder ||= activity_months_builder
+  end
+
+  ##
+  # Cached response; nil on error (see #error?).
+  #
+  def response
+    @response ||= fetch_cached do
+      activity_months_builder.response
+    end
+  rescue => e
+    Rails.logger.error(e)
+    record_ga_error(e)
+    nil
+  end
+
+  ##
+  # First day of the earliest month with activity; nil when none.
+  #
+  def earliest_month
+    month = response&.rows&.map(&:first)&.find { |m| m.to_s.match?(/\A\d{6}\z/) }
+    Date.strptime(month, "%Y%m") if month
+  end
+
+  private
+
+  ##
+  # Rows: [yearMonth, eventCount], earliest first. No hub = site-wide.
+  #
+  # @return GaResponseBuilder
+  # @throws exception if HTTP request fails
+  #
+  def activity_months_builder
+    filters = []
+    filters = %W(ga:eventCategory=@#{@hub} ga:eventCategory!@Browse) if @hub
+    filters.concat %W(ga:eventAction==#{@contributor}) if @contributor
+
+    GaResponseBuilder.build do |builder|
+      builder.start_date = @start_date.iso8601
+      builder.end_date = @end_date.iso8601
+      builder.metrics = %w(ga:totalEvents)
+      builder.dimensions = %w(yearMonth)
+      builder.sort = %w(yearMonth)
+      builder.filters = filters
+    end
+  end
+end

--- a/app/views/shared/_contributor_sections.html.erb
+++ b/app/views/shared/_contributor_sections.html.erb
@@ -14,6 +14,8 @@
         <span class="tooltiptext"><%= website_use_tooltip %></span>
       </div>
 
+      <%= render partial: "shared/date_range_note", locals: { data_start_date: ga4_earliest_month } %>
+
       <%= render partial: "shared/frontend_use_metrics" %>
 
     </div>
@@ -26,6 +28,8 @@
     <div class="tooltip">
       <h2>Wikimedia Integration</h2>
     </div>
+
+    <%= render partial: "shared/date_range_note", locals: { data_start_date: wikimedia_start_date } %>
 
     <%= render partial: "shared/wikimedia_overview" %>
 

--- a/app/views/shared/_date_menu.html.erb
+++ b/app/views/shared/_date_menu.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 
   <p class="date-range-note">
-    Analytics data is available through <%= data_available_through %>.
+    Analytics data is available from <%= data_available_from %> through <%= data_available_through %>.
     Data updates in the first week of each month.
   </p>
 

--- a/app/views/shared/_frontend_use_metrics.html.erb
+++ b/app/views/shared/_frontend_use_metrics.html.erb
@@ -138,7 +138,14 @@
         @website_overview.users.to_i == 0 &&
         @website_overview.sessions.to_i == 0 %>
     <tr>
-      <td colspan="2" class="no-data">No activity recorded for this period.</td>
+      <% if ga4_earliest_month && @end_date && @end_date < ga4_earliest_month %>
+        <td colspan="2" class="no-data">
+          No data is available for <%= @target&.name || params[:contributor_id] || params[:hub_id] %>
+          before <%= ga4_earliest_month.strftime("%B %Y") %>.
+        </td>
+      <% else %>
+        <td colspan="2" class="no-data">No activity recorded for this period.</td>
+      <% end %>
     </tr>
   <% end %>
 </table>

--- a/app/views/shared/_hub_sections.html.erb
+++ b/app/views/shared/_hub_sections.html.erb
@@ -14,7 +14,7 @@
         <span class="tooltiptext"><%= website_use_tooltip %></span>
       </div>
 
-      <%= render partial: "shared/date_range_note", locals: { data_start_date: website_data_start_date } %>
+      <%= render partial: "shared/date_range_note", locals: { data_start_date: ga4_earliest_month } %>
 
       <%= render partial: "shared/frontend_use_metrics" %>
 
@@ -29,7 +29,7 @@
       <h2>Wikimedia Integration</h2>
     </div>
 
-    <%= render partial: "shared/date_range_note", locals: { data_start_date: @wikimedia_start_date } %>
+    <%= render partial: "shared/date_range_note", locals: { data_start_date: wikimedia_start_date } %>
 
     <%= render partial: "shared/wikimedia_overview" %>
 

--- a/spec/lib/date_setter_spec.rb
+++ b/spec/lib/date_setter_spec.rb
@@ -24,6 +24,12 @@ describe DateSetter do
     end
   end
 
+  describe '#picker_min_date' do
+    it 'defaults to min_date' do
+      expect(host.picker_min_date).to eq host.min_date
+    end
+  end
+
   describe '#assign_start_and_end_dates' do
     def assigned_dates
       host.assign_start_and_end_dates

--- a/spec/lib/ga_data_floor_spec.rb
+++ b/spec/lib/ga_data_floor_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe GaDataFloor do
+  let(:host_class) do
+    Class.new do
+      # Stand in for the one controller method the concerns call on include.
+      def self.helper_method(*); end
+
+      include DateSetter
+      include GaDataFloor
+      attr_accessor :params
+
+      def initialize(params = {})
+        @params = params
+      end
+    end
+  end
+  let(:host) { host_class.new({ hub_id: 'foo' }) }
+
+  before { allow(Date).to receive(:current).and_return(Date.new(2026, 7, 15)) }
+
+  def stub_earliest(date)
+    activity = instance_double(WebsiteActivityMonths, earliest_month: date)
+    allow(WebsiteActivityMonths).to receive(:build).and_return(activity)
+  end
+
+  describe '#picker_min_date' do
+    it 'is the earliest GA4 month with data' do
+      stub_earliest(Date.new(2025, 5, 1))
+      expect(host.picker_min_date).to eq Date.new(2025, 5, 1)
+    end
+
+    it 'falls back to min_date when the earliest month is unknown' do
+      stub_earliest(nil)
+      expect(host.picker_min_date).to eq host.min_date
+    end
+
+    it 'never starts after the last completed month' do
+      stub_earliest(Date.new(2026, 7, 1))
+      expect(host.picker_min_date).to eq Date.new(2026, 6, 1)
+    end
+  end
+
+  describe '#ga4_earliest_month' do
+    # Settling days: scan must end in the prior month to match a stored entry.
+    it 'ends the scan at the newest settled day' do
+      allow(Date).to receive(:current).and_return(Date.new(2026, 7, 2))
+
+      scan_end = nil
+      allow(WebsiteActivityMonths).to receive(:build) do |&config|
+        builder = WebsiteActivityMonths.new
+        config.call(builder)
+        scan_end = builder.instance_variable_get(:@end_date)
+        instance_double(WebsiteActivityMonths, earliest_month: nil)
+      end
+
+      host.ga4_earliest_month
+      expect(scan_end).to eq Date.new(2026, 5, 31)
+    end
+  end
+end

--- a/spec/lib/website_activity_months_spec.rb
+++ b/spec/lib/website_activity_months_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe WebsiteActivityMonths do
+  let(:activity) do
+    described_class.build do |b|
+      b.hub        = 'Some Hub'
+      b.start_date = Date.new(2018, 1, 1)
+      b.end_date   = Date.new(2026, 6, 30)
+    end
+  end
+
+  describe '#earliest_month' do
+    it 'returns the first day of the first month with activity' do
+      allow(activity).to receive(:response)
+        .and_return(double(rows: [%w[202505 12], %w[202506 40]]))
+      expect(activity.earliest_month).to eq Date.new(2025, 5, 1)
+    end
+
+    it 'is nil when the target has no activity' do
+      allow(activity).to receive(:response).and_return(double(rows: []))
+      expect(activity.earliest_month).to be_nil
+    end
+
+    it 'is nil when the query failed' do
+      allow(activity).to receive(:response).and_return(nil)
+      expect(activity.earliest_month).to be_nil
+    end
+
+    it 'skips rows that are not year-months' do
+      allow(activity).to receive(:response)
+        .and_return(double(rows: [['(other)', '5'], %w[202507 8]]))
+      expect(activity.earliest_month).to eq Date.new(2025, 7, 1)
+    end
+  end
+end

--- a/spec/requests/contributor_management_spec.rb
+++ b/spec/requests/contributor_management_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe "Contributor management", :type => :request do
       }
     )
     allow(HubStats).to receive(:fetch_bws).and_return("hubs" => {})
+    # Keeps renders off GA4 (date-menu floor lookup).
+    allow(WebsiteActivityMonths).to receive(:build)
+      .and_return(instance_double(WebsiteActivityMonths, earliest_month: nil))
   end
 
   context "user not logged in" do

--- a/spec/requests/hub_management_spec.rb
+++ b/spec/requests/hub_management_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe "Hub management", :type => :request do
       }
     )
     allow(HubStats).to receive(:fetch_bws).and_return("hubs" => {})
+    # Keeps renders off GA4 (date-menu floor lookup).
+    allow(WebsiteActivityMonths).to receive(:build)
+      .and_return(instance_double(WebsiteActivityMonths, earliest_month: nil))
   end
 
   context "user not logged in" do

--- a/spec/requests/pagination_spec.rb
+++ b/spec/requests/pagination_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe "Table pagination", type: :request do
                             admin: true,
                             hub: "All") }
 
-  before(:each) { sign_in admin }
+  before(:each) do
+    sign_in admin
+    # Keeps renders off GA4 (date-menu floor lookup).
+    allow(WebsiteActivityMonths).to receive(:build)
+      .and_return(instance_double(WebsiteActivityMonths, earliest_month: nil))
+  end
 
   # Builds a Ga4Response from a stubbed GA4 report.
   def ga4_page(rows:, total:, dimensions:, metrics:)


### PR DESCRIPTION
Resolves https://github.com/dpla/dashboard-analytics/issues/290

For date pickers throughout the dashboard, the minimum date is now calculated to reflect the earliest available data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date pickers now reflect the earliest available analytics and Wikimedia data.
  * Availability notes show both start and end dates, with clearer data-range messaging.
  * No-activity messages now explain when a selected period predates available analytics.
  * Monthly activity data is used to identify the earliest valid reporting month.

* **Bug Fixes**
  * Improved date-range handling across hubs, contributors, locations, search terms, and timelines.

* **Tests**
  * Added coverage for date boundaries, earliest activity months, fallbacks, and unavailable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->